### PR TITLE
Implement worker interprocess communication to facilitate failure communcation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,6 +241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +341,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -441,6 +456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +506,12 @@ checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam"
@@ -607,6 +634,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "errno"
@@ -818,10 +851,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1106,6 +1162,7 @@ dependencies = [
  "num-traits",
  "paladin-opkind-derive",
  "pin-project",
+ "postcard",
  "serde",
  "thiserror",
  "tokio",
@@ -1229,6 +1286,18 @@ dependencies = [
  "log",
  "pin-project-lite",
  "windows-sys",
+]
+
+[[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -1380,6 +1449,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1503,6 +1581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+
+[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1611,6 +1695,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1119,7 +1119,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-opkind-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "des"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +758,12 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -1011,6 +1030,7 @@ dependencies = [
  "backoff",
  "ciborium",
  "clap",
+ "dashmap",
  "dotenvy",
  "futures",
  "lapin",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,6 +971,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,6 +1098,7 @@ dependencies = [
  "bytes",
  "ciborium",
  "clap",
+ "crossbeam",
  "dashmap",
  "dotenvy",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "bytes",
  "ciborium",
  "clap",
  "dashmap",

--- a/examples/hello-world-rabbitmq/Cargo.lock
+++ b/examples/hello-world-rabbitmq/Cargo.lock
@@ -241,6 +241,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,6 +341,12 @@ name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -441,6 +456,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
+name = "cobs"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -485,6 +506,12 @@ checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "crossbeam"
@@ -607,6 +634,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "errno"
@@ -818,10 +851,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
@@ -1104,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1119,6 +1175,7 @@ dependencies = [
  "lapin",
  "paladin-opkind-derive",
  "pin-project",
+ "postcard",
  "serde",
  "thiserror",
  "tokio",
@@ -1132,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-opkind-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "quote",
  "syn",
@@ -1242,6 +1299,18 @@ dependencies = [
  "log",
  "pin-project-lite",
  "windows-sys",
+]
+
+[[package]]
+name = "postcard"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55c51ee6c0db07e68448e336cf8ea4131a620edefebf9893e759b2d793420f8"
+dependencies = [
+ "cobs",
+ "embedded-io",
+ "heapless",
+ "serde",
 ]
 
 [[package]]
@@ -1393,6 +1462,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
+
+[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1624,6 +1708,12 @@ checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"

--- a/examples/hello-world-rabbitmq/Cargo.lock
+++ b/examples/hello-world-rabbitmq/Cargo.lock
@@ -506,6 +506,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "des"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +758,12 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
 
 [[package]]
 name = "heck"
@@ -1024,8 +1043,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backoff",
+ "bytes",
  "ciborium",
  "clap",
+ "dashmap",
  "dotenvy",
  "futures",
  "lapin",

--- a/examples/hello-world-rabbitmq/Cargo.lock
+++ b/examples/hello-world-rabbitmq/Cargo.lock
@@ -487,6 +487,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cfb3ea8a53f37c40dea2c7bedcbd88bdfae54f5e2175d6ecaff1c988353add"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,6 +986,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,7 +1075,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 name = "ops"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "paladin-core",
  "serde",
 ]
@@ -1046,6 +1112,7 @@ dependencies = [
  "bytes",
  "ciborium",
  "clap",
+ "crossbeam",
  "dashmap",
  "dotenvy",
  "futures",

--- a/examples/hello-world-rabbitmq/ops/Cargo.toml
+++ b/examples/hello-world-rabbitmq/ops/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 
 [dependencies]
 serde = "1.0.183"
-anyhow = "1.0.75"
 
 paladin-core = { path = "../../../paladin-core" }

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = "1.0.50"
 backoff = { version = "0.4.0", features = ["tokio"] }
 dashmap = "5.5.3"
 bytes = "1.5.0"
+crossbeam = "0.8.2"
 
 # Local dependencies
 paladin-opkind-derive = { path = "../paladin-opkind-derive" }

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -38,6 +38,7 @@ backoff = { version = "0.4.0", features = ["tokio"] }
 dashmap = "5.5.3"
 bytes = "1.5.0"
 crossbeam = "0.8.2"
+postcard = { version = "1.0.8", features = ["alloc"] }
 
 # Local dependencies
 paladin-opkind-derive = { path = "../paladin-opkind-derive" }

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -35,6 +35,7 @@ clap = { version = "4.4.2", features = ["derive", "env"] }
 pin-project = "1.1.3"
 thiserror = "1.0.50"
 backoff = { version = "0.4.0", features = ["tokio"] }
+dashmap = "5.5.3"
 
 # Local dependencies
 paladin-opkind-derive = { path = "../paladin-opkind-derive" }

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paladin-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Rust distributed algorithm toolkit. Write distributed algorithms without the complexities of distributed systems programming."
 license.workspace = true
 edition.workspace = true

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -36,6 +36,7 @@ pin-project = "1.1.3"
 thiserror = "1.0.50"
 backoff = { version = "0.4.0", features = ["tokio"] }
 dashmap = "5.5.3"
+bytes = "1.5.0"
 
 # Local dependencies
 paladin-opkind-derive = { path = "../paladin-opkind-derive" }

--- a/paladin-core/src/acker.rs
+++ b/paladin-core/src/acker.rs
@@ -67,6 +67,8 @@
 //! # Ok(())
 //! # }
 //! ```
+use std::sync::Arc;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::TryFutureExt;
@@ -89,6 +91,18 @@ pub trait Acker: Send + Sync + 'static {
 /// dispatched types.
 #[async_trait]
 impl<T: Acker + ?Sized> Acker for Box<T> {
+    async fn ack(&self) -> Result<()> {
+        (**self).ack().await
+    }
+
+    async fn nack(&self) -> Result<()> {
+        (**self).nack().await
+    }
+}
+
+/// Provides an implementation of the `Acker` trait for `Arc` types.
+#[async_trait]
+impl<T: Acker + ?Sized> Acker for Arc<T> {
     async fn ack(&self) -> Result<()> {
         (**self).ack().await
     }

--- a/paladin-core/src/channel/queue.rs
+++ b/paladin-core/src/channel/queue.rs
@@ -12,7 +12,6 @@
 //!
 //! ```no_run
 //! use paladin::{
-//!     serializer::Serializer,
 //!     queue::{Connection, amqp::{AMQPConnection, AMQPConnectionOptions}},
 //!     channel::{Channel, ChannelType, ChannelFactory, queue::QueueChannelFactory},
 //! };
@@ -31,7 +30,7 @@
 //!     let conn = AMQPConnection::new(AMQPConnectionOptions {
 //!         uri: "amqp://localhost:5672",
 //!         qos: Some(1),
-//!         serializer: Serializer::Cbor,
+//!         serializer: Default::default(),
 //!     }).await?;
 //!
 //!     // Build the factory
@@ -50,7 +49,6 @@
 //!
 //! ```no_run
 //! use paladin::{
-//!     serializer::Serializer,
 //!     acker::Acker,
 //!     queue::{Connection, amqp::{AMQPConnection, AMQPConnectionOptions}},
 //!     channel::{Channel, ChannelType, ChannelFactory, queue::QueueChannelFactory},
@@ -70,7 +68,7 @@
 //!     let conn = AMQPConnection::new(AMQPConnectionOptions {
 //!         uri: "amqp://localhost:5672",
 //!         qos: Some(1),
-//!         serializer: Serializer::Cbor,
+//!         serializer: Default::default(),
 //!     }).await?;
 //!
 //!     // Build the factory

--- a/paladin-core/src/channel/queue.rs
+++ b/paladin-core/src/channel/queue.rs
@@ -1,5 +1,5 @@
 //! [`Channel`] and [`ChannelFactory`] implementations generic over a
-//! [`Queue`](crate::queue::Queue).
+//! [`Connection`].
 //!
 //! This allows any queue implementation, such as RabbitMQ, Kafka, etc, to be
 //! used like a [`Channel`]. Downstream code can interact with a queue as if it
@@ -13,8 +13,8 @@
 //! ```no_run
 //! use paladin::{
 //!     serializer::Serializer,
-//!     queue::{Queue, Connection, amqp::{AMQPQueue, AMQPQueueOptions}},
-//!     channel::{Channel, ChannelFactory, queue::QueueChannelFactory},
+//!     queue::{Connection, amqp::{AMQPConnection, AMQPConnectionOptions}},
+//!     channel::{Channel, ChannelType, ChannelFactory, queue::QueueChannelFactory},
 //! };
 //! use serde::{Serialize, Deserialize};
 //! use anyhow::Result;
@@ -27,18 +27,17 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!    // Establish a connection
-//!    let amqp = AMQPQueue::new(AMQPQueueOptions {
+//!     // Establish a connection
+//!     let conn = AMQPConnection::new(AMQPConnectionOptions {
 //!         uri: "amqp://localhost:5672",
 //!         qos: Some(1),
 //!         serializer: Serializer::Cbor,
-//!     });
-//!     let conn = amqp.get_connection().await?;
+//!     }).await?;
 //!
 //!     // Build the factory
 //!     let amqp_channel_factory = QueueChannelFactory::new(conn);
 //!     // Get a channel
-//!     let channel = amqp_channel_factory.get("my_queue").await?;
+//!     let channel = amqp_channel_factory.get("my_queue", ChannelType::ExactlyOnce).await?;
 //!     // Get a sender pipe
 //!     let mut sender = channel.sender::<MyStruct>().await?;
 //!     // Dispatch a message
@@ -53,8 +52,8 @@
 //! use paladin::{
 //!     serializer::Serializer,
 //!     acker::Acker,
-//!     queue::{Queue, Connection, amqp::{AMQPQueue, AMQPQueueOptions}},
-//!     channel::{Channel, ChannelFactory, queue::QueueChannelFactory},
+//!     queue::{Connection, amqp::{AMQPConnection, AMQPConnectionOptions}},
+//!     channel::{Channel, ChannelType, ChannelFactory, queue::QueueChannelFactory},
 //! };
 //! use serde::{Serialize, Deserialize};
 //! use anyhow::Result;
@@ -67,18 +66,17 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
-//!    // Establish a connection
-//!    let amqp = AMQPQueue::new(AMQPQueueOptions {
+//!     // Establish a connection
+//!     let conn = AMQPConnection::new(AMQPConnectionOptions {
 //!         uri: "amqp://localhost:5672",
 //!         qos: Some(1),
 //!         serializer: Serializer::Cbor,
-//!     });
-//!     let conn = amqp.get_connection().await?;
+//!     }).await?;
 //!
 //!     // Build the factory
 //!     let amqp_channel_factory = QueueChannelFactory::new(conn);
 //!     // Get a channel
-//!     let channel = amqp_channel_factory.get("my_queue").await?;
+//!     let channel = amqp_channel_factory.get("my_queue", ChannelType::ExactlyOnce).await?;
 //!     // Get a receiver pipe
 //!     let mut receiver = channel.receiver::<MyStruct>().await?;
 //!     // Receive messages
@@ -95,18 +93,38 @@ use async_trait::async_trait;
 use uuid::Uuid;
 
 use crate::{
-    channel::{Channel, ChannelFactory},
-    queue::{sink::QueueSink, Connection, Consumer, QueueHandle},
+    channel::{Channel, ChannelFactory, ChannelType},
+    queue::{
+        sink::QueueSink, Connection, DeliveryMode, QueueDurability, QueueHandle, QueueOptions,
+        SyndicationMode,
+    },
     serializer::Serializable,
 };
 
+impl From<ChannelType> for QueueOptions {
+    fn from(channel_type: ChannelType) -> Self {
+        match channel_type {
+            ChannelType::ExactlyOnce => QueueOptions {
+                syndication_mode: SyndicationMode::ExactlyOnce,
+                delivery_mode: DeliveryMode::Persistent,
+                durability: QueueDurability::NonDurable,
+            },
+            ChannelType::Broadcast => QueueOptions {
+                syndication_mode: SyndicationMode::Broadcast,
+                delivery_mode: DeliveryMode::Persistent,
+                durability: QueueDurability::NonDurable,
+            },
+        }
+    }
+}
+
 /// A [`ChannelFactory`] implementation for a queue.
 #[derive(Clone)]
-pub struct QueueChannelFactory<Conn: Connection> {
+pub struct QueueChannelFactory<Conn> {
     connection: Conn,
 }
 
-impl<Conn: Connection> QueueChannelFactory<Conn> {
+impl<Conn> QueueChannelFactory<Conn> {
     pub fn new(connection: Conn) -> Self {
         Self { connection }
     }
@@ -117,21 +135,21 @@ impl<Conn: Connection> QueueChannelFactory<Conn> {
 /// Note that sender, receiver, and release operations are all lazily evaluated
 /// -- the resources aren't actually allocated until they are used.
 #[derive(Clone)]
-pub struct QueueChannel<Conn: Connection> {
+pub struct QueueChannel<Conn> {
     connection: Conn,
     identifier: String,
+    channel_type: ChannelType,
 }
 
 #[async_trait]
 impl<
-        CHandle: Consumer,
-        QHandle: QueueHandle<Consumer = CHandle>,
-        Conn: Connection<QueueHandle = QHandle>,
+        QHandle: QueueHandle + Send + Sync + 'static,
+        Conn: Connection<QueueHandle = QHandle> + Send + Sync + 'static,
     > Channel for QueueChannel<Conn>
 {
-    type Acker = CHandle::Acker;
+    type Acker = <QHandle as QueueHandle>::Acker;
     type Sender<T: Serializable> = QueueSink<T, QHandle>;
-    type Receiver<T: Serializable> = CHandle::Stream<T>;
+    type Receiver<T: Serializable> = <QHandle as QueueHandle>::Consumer<T>;
 
     /// Close the underlying connection.
     async fn close(&self) -> Result<()> {
@@ -141,45 +159,59 @@ impl<
 
     /// Get a sender for the underlying queue.
     async fn sender<T: Serializable>(&self) -> Result<Self::Sender<T>> {
-        let queue = self.connection.declare_queue(&self.identifier).await?;
+        let queue = self
+            .connection
+            .declare_queue(&self.identifier, self.channel_type.into())
+            .await?;
         Ok(QueueSink::new(queue))
     }
 
     /// Get a receiver for the underlying queue.
     async fn receiver<T: Serializable>(&self) -> Result<Self::Receiver<T>> {
-        let queue = self.connection.declare_queue(&self.identifier).await?;
+        let queue = self
+            .connection
+            .declare_queue(&self.identifier, self.channel_type.into())
+            .await?;
         let consumer = queue.declare_consumer(&Uuid::new_v4().to_string()).await?;
 
-        Ok(consumer.stream().await?)
+        Ok(consumer)
     }
 
     /// Delete the underlying queue.
-    async fn release(&self) -> Result<()> {
-        self.connection.delete_queue(&self.identifier).await?;
-        Ok(())
+    fn release(&self) {
+        let conn = self.connection.clone();
+        let identifier = self.identifier.clone();
+        tokio::spawn(async move {
+            _ = conn.delete_queue(&identifier).await;
+        });
     }
 }
 
 #[async_trait]
-impl<Conn: Connection> ChannelFactory for QueueChannelFactory<Conn> {
+impl<Conn: Connection + Send + Sync + 'static> ChannelFactory for QueueChannelFactory<Conn>
+where
+    <Conn as Connection>::QueueHandle: Send + Sync + 'static,
+{
     type Channel = QueueChannel<Conn>;
 
     /// Get an existing channel.
-    async fn get(&self, identifier: &str) -> Result<Self::Channel> {
+    async fn get(&self, identifier: &str, channel_type: ChannelType) -> Result<Self::Channel> {
         Ok(QueueChannel {
             connection: self.connection.clone(),
             identifier: identifier.to_string(),
+            channel_type,
         })
     }
 
     /// Issue a new channel, generating a new UUID as the identifier.
-    async fn issue(&self) -> Result<(String, Self::Channel)> {
+    async fn issue(&self, channel_type: ChannelType) -> Result<(String, Self::Channel)> {
         let identifier = Uuid::new_v4().to_string();
         Ok((
             identifier.clone(),
             QueueChannel {
                 connection: self.connection.clone(),
                 identifier,
+                channel_type,
             },
         ))
     }

--- a/paladin-core/src/channel/queue.rs
+++ b/paladin-core/src/channel/queue.rs
@@ -148,7 +148,7 @@ impl<
     /// Get a receiver for the underlying queue.
     async fn receiver<T: Serializable>(&self) -> Result<Self::Receiver<T>> {
         let queue = self.connection.declare_queue(&self.identifier).await?;
-        let consumer = queue.declare_consumer("").await?;
+        let consumer = queue.declare_consumer(&Uuid::new_v4().to_string()).await?;
 
         Ok(consumer.stream().await?)
     }

--- a/paladin-core/src/config/mod.rs
+++ b/paladin-core/src/config/mod.rs
@@ -28,7 +28,7 @@ pub struct Config {
     pub task_bus_routing_key: String,
 
     /// Determines the serialization format to be used.
-    #[arg(long, short, value_enum, default_value_t = Serializer::Cbor)]
+    #[arg(long, short, value_enum, default_value_t = Serializer::Postcard)]
     pub serializer: Serializer,
 
     /// Specifies the runtime environment to use.
@@ -49,6 +49,7 @@ pub struct Config {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, ValueEnum, Default)]
 pub enum Serializer {
     #[default]
+    Postcard,
     Cbor,
 }
 

--- a/paladin-core/src/queue/amqp.rs
+++ b/paladin-core/src/queue/amqp.rs
@@ -4,7 +4,6 @@
 //!
 //! ```no_run
 //! use paladin::{
-//!     serializer::Serializer,
 //!     acker::Acker,
 //!     queue::{
 //!         Connection, QueueOptions, QueueHandle,
@@ -25,7 +24,7 @@
 //!     let conn = AMQPConnection::new(AMQPConnectionOptions {
 //!         uri: "amqp://localhost:5672",
 //!         qos: Some(1),
-//!         serializer: Serializer::Cbor,
+//!         serializer: Default::default(),
 //!     }).await?;
 //!     let queue = conn.declare_queue("my_queue", QueueOptions::default()).await?;
 //!
@@ -140,14 +139,13 @@ pub struct AMQPConnectionOptions<'a> {
 /// use paladin::queue::{
 ///     amqp::{AMQPConnection, AMQPConnectionOptions}
 /// };
-/// use paladin::serializer::Serializer;
 /// # use anyhow::Result;
 /// # #[tokio::main]
 /// # async fn main() -> Result<()> {
 /// let conn = AMQPConnection::new(AMQPConnectionOptions {
 ///     uri: "amqp://localhost:5672",
 ///     qos: Some(1),
-///     serializer: Serializer::Cbor,
+///     serializer: Default::default(),
 /// }).await?;
 ///
 /// Ok(())
@@ -287,7 +285,6 @@ impl Connection for AMQPConnection {
     ///
     /// ```no_run
     /// # use paladin::{
-    ///     serializer::Serializer,
     ///     queue::{Connection, QueueOptions, amqp::{AMQPConnection, AMQPConnectionOptions}}
     /// };
     /// # use anyhow::Result;
@@ -296,7 +293,7 @@ impl Connection for AMQPConnection {
     /// let conn = AMQPConnection::new(AMQPConnectionOptions {
     ///     uri: "amqp://localhost:5672",
     ///     qos: Some(1),
-    ///     serializer: Serializer::Cbor,
+    ///     serializer: Default::default(),
     /// }).await?;
     /// let queue = conn.declare_queue("my_queue", QueueOptions::default()).await?;
     ///
@@ -383,7 +380,6 @@ impl QueueHandle for AMQPQueueHandle {
     /// # Example
     /// ```no_run
     /// use paladin::{
-    ///     serializer::Serializer,
     ///     queue::{
     ///         Connection,
     ///         QueueHandle,
@@ -404,7 +400,7 @@ impl QueueHandle for AMQPQueueHandle {
     ///     let conn = AMQPConnection::new(AMQPConnectionOptions {
     ///         uri: "amqp://localhost:5672",
     ///         qos: Some(1),
-    ///         serializer: Serializer::Cbor,
+    ///         serializer: Default::default(),
     ///     }).await?;
     ///     let queue = conn.declare_queue("my_queue", QueueOptions::default()).await?;
     ///
@@ -427,7 +423,6 @@ impl QueueHandle for AMQPQueueHandle {
     /// Get a consumer instance to the queue.
     /// ```no_run
     /// use paladin::{
-    ///     serializer::Serializer,
     ///     queue::{
     ///         Connection,
     ///         QueueHandle,
@@ -448,7 +443,7 @@ impl QueueHandle for AMQPQueueHandle {
     ///     let conn = AMQPConnection::new(AMQPConnectionOptions {
     ///         uri: "amqp://localhost:5672",
     ///         qos: Some(1),
-    ///         serializer: Serializer::Cbor,
+    ///         serializer: Default::default(),
     ///     }).await?;
     ///     let queue = conn.declare_queue("my_queue", QueueOptions::default()).await?;
     ///

--- a/paladin-core/src/queue/in_memory.rs
+++ b/paladin-core/src/queue/in_memory.rs
@@ -773,7 +773,7 @@ mod broadcast {
     use crate::queue::*;
 
     async fn broadcast_handle() -> InMemoryQueueHandle {
-        let connection = InMemoryConnection::new(Serializer::Cbor);
+        let connection = InMemoryConnection::new(Default::default());
         connection
             .declare_queue(
                 "my_broadcast_queue",

--- a/paladin-core/src/queue/in_memory.rs
+++ b/paladin-core/src/queue/in_memory.rs
@@ -1,4 +1,4 @@
-//! An in-memory implementation of [`Queue`] and its associated types.
+//! An in-memory implementation of [`Connection`] and its associated types.
 //!
 //! This implementation is useful for testing and debugging purposes, as it
 //! provides a simple, in-memory queue that can be used to emulate a real queue.
@@ -10,67 +10,29 @@
 //! pool to a real queue. Each clone of the connection will maintain references
 //! to same underlying queues.
 use std::{
-    collections::VecDeque,
-    ops::Deref,
-    pin::{pin, Pin},
-    sync::Arc,
+    collections::HashMap,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc,
+    },
     task::{Context, Poll},
 };
 
 use anyhow::Result;
 use async_trait::async_trait;
 use bytes::Bytes;
+use crossbeam::queue::SegQueue;
 use dashmap::{mapref::entry::Entry, DashMap};
-use futures::{
-    lock::{Mutex, OwnedMutexLockFuture},
-    ready, Future, Stream,
-};
-use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
+use futures::{ready, Stream};
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use tokio_util::sync::PollSemaphore;
 
-use super::{Connection, Consumer, Queue, QueueHandle};
+use super::{Connection, DeliveryMode, QueueHandle, QueueOptions, SyndicationMode};
 use crate::{
     acker::NoopAcker,
     serializer::{Serializable, Serializer},
 };
-
-/// An in-memory implementation of [`Queue`].
-///
-/// ```
-/// use paladin::queue::{Queue, in_memory::InMemoryQueue};
-/// use paladin::serializer::Serializer;
-/// use anyhow::Result;
-///
-/// #[tokio::main]
-/// async fn main() -> Result<()> {
-///     let queue = InMemoryQueue::new(Serializer::Cbor);
-///     let connection = queue.get_connection().await?;
-///     
-///     Ok(())
-/// }
-/// ```
-pub struct InMemoryQueue {
-    /// The connection to the queue.
-    connection: InMemoryConnection,
-}
-
-impl InMemoryQueue {
-    /// Create a new in-memory queue.
-    pub fn new(serializer: Serializer) -> Self {
-        Self {
-            connection: InMemoryConnection::new(serializer),
-        }
-    }
-}
-
-#[async_trait]
-impl Queue for InMemoryQueue {
-    type Connection = InMemoryConnection;
-
-    async fn get_connection(&self) -> Result<Self::Connection> {
-        Ok(self.connection.clone())
-    }
-}
 
 /// An in-memory implementation of [`Connection`].
 ///
@@ -79,16 +41,15 @@ impl Queue for InMemoryQueue {
 /// queues.
 ///
 /// ```
-/// use paladin::queue::{Queue, Connection, in_memory::InMemoryQueue};
+/// use paladin::queue::{Connection, QueueOptions, in_memory::InMemoryConnection};
 /// use paladin::serializer::Serializer;
 /// use anyhow::Result;
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<()> {
-///     let queue = InMemoryQueue::new(Serializer::Cbor);
-///     let connection = queue.get_connection().await?;
+///     let connection = InMemoryConnection::new(Serializer::default());
 ///     // Declare a queue
-///     let handle = connection.declare_queue("my_queue").await?;
+///     let handle = connection.declare_queue("my_queue", QueueOptions::default()).await?;
 ///
 ///     // ...
 ///     // Delete a queue
@@ -105,12 +66,6 @@ pub struct InMemoryConnection {
     /// counted pointer to allow for multiple clones of the connection to
     /// maintain references to the same queues.
     queues: Arc<DashMap<String, InMemoryQueueHandle>>,
-    /// The broadcasts managed by this connection.
-    ///
-    /// Broadcasts are indexed by their name and stored in an atomically
-    /// reference counted pointer to allow for multiple clones of the connection
-    /// to maintain references to the same broadcasts.
-    broadcasts: Arc<DashMap<String, InMemoryBroadcastHandle>>,
     /// The serializer to use for serializing and deserializing messages.
     serializer: Serializer,
 }
@@ -119,7 +74,6 @@ impl InMemoryConnection {
     pub fn new(serializer: Serializer) -> Self {
         Self {
             queues: Default::default(),
-            broadcasts: Default::default(),
             serializer,
         }
     }
@@ -128,17 +82,16 @@ impl InMemoryConnection {
 #[async_trait]
 impl Connection for InMemoryConnection {
     type QueueHandle = InMemoryQueueHandle;
-    type BroadcastHandle = InMemoryBroadcastHandle;
 
     async fn close(&self) -> Result<()> {
         Ok(())
     }
 
-    async fn declare_queue(&self, name: &str) -> Result<Self::QueueHandle> {
+    async fn declare_queue(&self, name: &str, options: QueueOptions) -> Result<Self::QueueHandle> {
         match self.queues.entry(name.to_string()) {
             Entry::Occupied(entry) => Ok(entry.get().clone()),
             Entry::Vacant(entry) => {
-                let queue = InMemoryQueueHandle::new(self.serializer);
+                let queue = InMemoryQueueHandle::new(self.serializer, options);
                 entry.insert(queue.clone());
                 Ok(queue)
             }
@@ -150,162 +103,254 @@ impl Connection for InMemoryConnection {
 
         Ok(())
     }
-
-    async fn declare_broadcast(&self, name: &str) -> Result<Self::BroadcastHandle> {
-        match self.broadcasts.entry(name.to_string()) {
-            Entry::Occupied(entry) => Ok(entry.get().clone()),
-            Entry::Vacant(entry) => {
-                let queue = InMemoryBroadcastHandle::new(self.serializer);
-                entry.insert(queue.clone());
-                Ok(queue)
-            }
-        }
-    }
-
-    async fn delete_broadcast(&self, name: &str) -> Result<()> {
-        self.broadcasts.remove(name);
-
-        Ok(())
-    }
 }
 
-/// An per-consumer queue for [`InMemoryBroadcastHandle`].
+/// Queue implementation for [`SyndicationMode::ExactlyOnce`].
 ///
-/// This queue is used to synchronize messages between the broadcast handle and
-/// its consumers. The [`InMemoryConsumer`] will be able to pull messages from
-/// this queue, and the associated [`InMemoryBroadcastHandle`] will be able to
-/// push messages to this queue.
+/// Exactly once queues must guarantee that each message is delivered to exactly
+/// one consumer. As such, this implementation only has a single `messages`
+/// queue, from which, all consumers will pop messages.
 #[derive(Clone)]
-pub struct ConsumerBroadcastQueue {
+struct ExactlyOnceQueue {
     /// The messages in the queue.
-    messages: Arc<Mutex<VecDeque<Bytes>>>,
+    messages: Arc<SegQueue<Bytes>>,
     /// The number of messages in the queue.
     num_messages: PollSemaphore,
-}
-
-/// An in-memory implementation of [`QueueHandle`] for broadcast queues.
-///
-/// # Example
-///
-/// ```
-/// # use paladin::{
-/// #    serializer::Serializer,
-/// #    acker::Acker,
-/// #    queue::{Queue, Connection, QueueHandle, Consumer, in_memory::InMemoryQueue}
-/// # };
-/// # use serde::{Serialize, Deserialize};
-/// # use anyhow::Result;
-/// # use futures::StreamExt;
-///
-/// #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
-/// struct MyStruct {
-///     field: String,
-/// }
-///
-/// #[tokio::main]
-/// async fn main() -> Result<()> {
-///     let queue = InMemoryQueue::new(Serializer::Cbor);
-///     let connection = queue.get_connection().await?;
-///     // Declare a queue
-///     let handle = connection.declare_broadcast("my_queue").await?;
-///
-///     // Publish a message
-///     handle.publish(&MyStruct { field: "Hello, World!".to_string() }).await?;
-///
-///     // Consume the message in the first consumer
-///     let consumer = handle.declare_consumer("consumer_1").await?;
-///     if let Some((message, acker)) = consumer.stream::<MyStruct>().await?.next().await {
-///         acker.ack().await?;
-///         assert_eq!(message, MyStruct { field: "Hello, World!".to_string() });
-///     }
-///
-///     // Consume the message in the second consumer
-///     let consumer = handle.declare_consumer("consumer_2").await?;
-///     if let Some((message, acker)) = consumer.stream::<MyStruct>().await?.next().await {
-///         acker.ack().await?;
-///         assert_eq!(message, MyStruct { field: "Hello, World!".to_string() });
-///     }
-/// #
-/// #    Ok(())
-/// }
-/// ```
-#[derive(Clone)]
-pub struct InMemoryBroadcastHandle {
-    /// The consumers subscribed to the broadcast channel.
-    consumers: Arc<DashMap<String, ConsumerBroadcastQueue>>,
-    /// All messages.
-    ///
-    /// This can be used to replay messages to new consumers.
-    message_history: Arc<RwLock<VecDeque<Bytes>>>,
+    /// The queue options.
+    _options: QueueOptions,
     /// The serializer to use for serializing and deserializing messages.
     serializer: Serializer,
 }
 
-impl InMemoryBroadcastHandle {
-    pub fn new(serializer: Serializer) -> Self {
+impl Default for ExactlyOnceQueue {
+    fn default() -> Self {
         Self {
-            consumers: Default::default(),
-            message_history: Default::default(),
-            serializer,
+            messages: Default::default(),
+            num_messages: PollSemaphore::new(Arc::new(Semaphore::new(0))),
+            _options: Default::default(),
+            serializer: Default::default(),
         }
     }
 }
 
-#[async_trait]
-impl QueueHandle for InMemoryBroadcastHandle {
-    type Consumer = InMemoryConsumer<Bytes>;
+impl ExactlyOnceQueue {
+    fn new(options: QueueOptions, serializer: Serializer) -> Self {
+        Self {
+            messages: Default::default(),
+            num_messages: PollSemaphore::new(Arc::new(Semaphore::new(0))),
+            _options: options,
+            serializer,
+        }
+    }
 
-    /// Publish a message to the broadcast channel.
-    ///
-    /// This will push the message to all consumers of the broadcast channel.
-    async fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()> {
+    fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()> {
         let bytes = Bytes::from(self.serializer.to_bytes(payload)?);
-
-        {
-            let mut history = self.message_history.write().await;
-            history.push_back(bytes.clone());
-        }
-        for consumer in self.consumers.iter() {
-            let mut lock = consumer.messages.lock().await;
-            lock.push_back(bytes.clone());
-            consumer.num_messages.add_permits(1);
-        }
+        self.messages.push(bytes.clone());
+        self.num_messages.add_permits(1);
         Ok(())
     }
 
-    async fn declare_consumer(&self, consumer_name: &str) -> Result<Self::Consumer> {
-        let consumer = {
-            let message_history = self.message_history.read().await;
-            let messages: VecDeque<_> = message_history.iter().cloned().collect();
-            ConsumerBroadcastQueue {
-                num_messages: PollSemaphore::new(Arc::new(Semaphore::new(messages.len()))),
-                messages: Arc::new(Mutex::new(messages)),
-            }
-        };
-
-        self.consumers
-            .insert(consumer_name.to_string(), consumer.clone());
-
+    fn declare_consumer<PayloadTarget: Serializable>(
+        &self,
+        _consumer_name: &str,
+    ) -> Result<InMemoryConsumer<PayloadTarget>> {
         Ok(InMemoryConsumer {
-            messages: consumer.messages.clone(),
-            num_messages: consumer.num_messages.clone(),
+            messages: self.messages.clone(),
+            num_messages: self.num_messages.clone(),
             serializer: self.serializer,
+            permit: None,
+            _marker: std::marker::PhantomData,
         })
+    }
+}
+
+/// A per-consumer broadcast queue for [`InMemoryQueueHandle`].
+///
+/// This queue is used to synchronize messages between the broadcast handle and
+/// its consumers.
+///
+/// This differs from the implementation of [`ExactlyOnceQueue`] in that each
+/// consumer has its own queue of messages. This allows for each consumer to
+/// have its own queue of messages, which is required for broadcast queues.
+#[derive(Clone)]
+struct BroadcastConsumer {
+    /// The messages in the queue.
+    messages: Arc<SegQueue<Bytes>>,
+    /// The number of messages in the queue.
+    num_messages: PollSemaphore,
+    /// The seen message IDs.
+    seen: Arc<DashMap<u64, ()>>,
+}
+
+impl Default for BroadcastConsumer {
+    fn default() -> Self {
+        Self {
+            messages: Default::default(),
+            num_messages: PollSemaphore::new(Arc::new(Semaphore::new(0))),
+            seen: Default::default(),
+        }
+    }
+}
+
+/// Queue implementation for [`SyndicationMode::Broadcast`].
+///
+/// Broadcast queues must guarantee that each message is delivered to every
+/// consumer. As such, this implementation maintains a set of consumers, each
+/// with their own queue of messages.
+///
+/// # Design
+/// This implementation maintains a map of consumers, each with their own queue
+/// of messages. When a message is published, it is pushed to each consumer's
+/// queue.
+///
+/// A message history is maintained to support queues declared with the
+/// [`DeliveryMode::Persistent`] option. If this is enabled, messages will be
+/// pushed to the history queue when there are no consumers. When a new consumer
+/// is declared, the history queue will be drained into the new consumer's
+/// queue.
+///
+/// We maintain a global message counter to assign a unique ID to each message.
+/// This allows us to avoid sending messages to consumers that have already seen
+/// the message, especially in a heavily concurrent environment.
+#[derive(Clone, Default)]
+struct BroadcastQueue {
+    /// The consumers subscribed to the broadcast queue.
+    consumers: Arc<DashMap<String, BroadcastConsumer>>,
+    /// All messages.
+    ///
+    /// This can be used to replay messages to new consumers with delivery mode
+    /// set to [`DeliveryMode::Persistent`].
+    history: Arc<SegQueue<(u64, Bytes)>>,
+    /// A global message counter.
+    message_counter: Arc<AtomicU64>,
+    /// The queue options.
+    options: QueueOptions,
+    /// The serializer to use for serializing and deserializing messages.
+    serializer: Serializer,
+}
+
+impl BroadcastQueue {
+    fn new(options: QueueOptions, serializer: Serializer) -> Self {
+        Self {
+            options,
+            serializer,
+            ..Default::default()
+        }
+    }
+
+    fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()> {
+        let bytes = Bytes::from(self.serializer.to_bytes(payload)?);
+        // Assign a unique message ID to the message such that consumers can
+        // track which messages they've seen.
+        let message_id = self.message_counter.fetch_add(1, Ordering::Relaxed);
+
+        // If the delivery mode is persistent and there are no consumers, push
+        // the message to the history queue such that new consumers can replay
+        // the message.
+        if DeliveryMode::Persistent == self.options.delivery_mode && self.consumers.is_empty() {
+            self.history.push((message_id, bytes.clone()));
+        }
+
+        for consumer in self.consumers.iter() {
+            // Newly added consumers may _concurrently_ see messages from history while
+            // propagating the new message. In other words, a new consumer may come online
+            // _while_ new messages are being published. To prevent this, we check if the
+            // consumer has already seen the message.
+            if DeliveryMode::Persistent == self.options.delivery_mode {
+                match consumer.seen.entry(message_id) {
+                    Entry::Occupied(_) => continue,
+                    Entry::Vacant(entry) => {
+                        entry.insert(());
+                    }
+                }
+            }
+
+            consumer.messages.push(bytes.clone());
+            consumer.num_messages.add_permits(1);
+        }
+
+        Ok(())
+    }
+
+    fn declare_consumer<PayloadTarget: Serializable>(
+        &self,
+        consumer_name: &str,
+    ) -> Result<InMemoryConsumer<PayloadTarget>> {
+        match self.consumers.entry(consumer_name.to_string()) {
+            Entry::Occupied(entry) => {
+                let consumer = entry.get().clone();
+                Ok(InMemoryConsumer {
+                    messages: consumer.messages.clone(),
+                    num_messages: consumer.num_messages.clone(),
+                    serializer: self.serializer,
+                    permit: None,
+                    _marker: std::marker::PhantomData,
+                })
+            }
+            Entry::Vacant(entry) => {
+                // If the delivery mode is persistent and there are messages in
+                // the history queue, there are unseen messages that need to be
+                // replayed.
+                let (messages, seen) = if DeliveryMode::Persistent == self.options.delivery_mode
+                    && !self.history.is_empty()
+                {
+                    let messages = SegQueue::new();
+                    let mut seen = HashMap::new();
+
+                    // Populate the new consumer's queue with messages from the
+                    // history queue.
+                    while let Some((message_id, message)) = self.history.pop() {
+                        // Ensure that during a concurrent publish the message is not replayed.
+                        match seen.entry(message_id) {
+                            std::collections::hash_map::Entry::Occupied(_) => continue,
+                            std::collections::hash_map::Entry::Vacant(entry) => {
+                                entry.insert(());
+                            }
+                        }
+
+                        messages.push(message);
+                    }
+                    (messages, seen)
+                } else {
+                    (Default::default(), Default::default())
+                };
+
+                let consumer = BroadcastConsumer {
+                    num_messages: PollSemaphore::new(Arc::new(Semaphore::new(seen.len()))),
+                    messages: Arc::new(messages),
+                    seen: Arc::new(seen.into_iter().collect()),
+                };
+
+                entry.insert(consumer.clone());
+                Ok(InMemoryConsumer {
+                    messages: consumer.messages.clone(),
+                    num_messages: consumer.num_messages.clone(),
+                    serializer: self.serializer,
+                    permit: None,
+                    _marker: std::marker::PhantomData,
+                })
+            }
+        }
     }
 }
 
 /// An in-memory implementation of [`QueueHandle`].
 ///
-/// Cloning this handle will create a new handle that points to the same set of
-/// messages and synchronization state.
-///
 /// # Example
 ///
+/// ## Exactly Once Mode
 /// ```
 /// # use paladin::{
-/// #    serializer::Serializer,
-/// #    acker::Acker,
-/// #    queue::{Queue, Connection, QueueHandle, Consumer, in_memory::InMemoryQueue}
+/// #     serializer::Serializer,
+/// #     acker::Acker,
+/// #     queue::{
+/// #         Connection,
+/// #         SyndicationMode,
+/// #         DeliveryMode,
+/// #         QueueOptions,
+/// #         QueueHandle,
+/// #         in_memory::InMemoryConnection,
+/// #     }
 /// # };
 /// # use serde::{Serialize, Deserialize};
 /// # use anyhow::Result;
@@ -318,17 +363,21 @@ impl QueueHandle for InMemoryBroadcastHandle {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<()> {
-///     let queue = InMemoryQueue::new(Serializer::Cbor);
-///     let connection = queue.get_connection().await?;
+///     let connection = InMemoryConnection::new(Serializer::default());
+///
 ///     // Declare a queue
-///     let handle = connection.declare_queue("my_queue").await?;
+///     let handle = connection.declare_queue("my_queue", QueueOptions {
+///         syndication_mode: SyndicationMode::ExactlyOnce,
+///         delivery_mode: DeliveryMode::Persistent,
+///         ..Default::default()
+///     }).await?;
 ///
 ///     // Publish a message
 ///     handle.publish(&MyStruct { field: "Hello, World!".to_string() }).await?;
 ///
 ///     // Consume the message
-///     let consumer = handle.declare_consumer("my_consumer").await?;
-///     if let Some((message, acker)) = consumer.stream::<MyStruct>().await?.next().await {
+///     let mut consumer = handle.declare_consumer::<MyStruct>("my_consumer").await?;
+///     if let Some((message, acker)) = consumer.next().await {
 ///         acker.ack().await?;
 ///         assert_eq!(message, MyStruct { field: "Hello, World!".to_string() });
 ///     }
@@ -336,62 +385,24 @@ impl QueueHandle for InMemoryBroadcastHandle {
 /// #    Ok(())
 /// }
 /// ```
-#[derive(Clone)]
-pub struct InMemoryQueueHandle {
-    /// The messages in the queue.
-    ///
-    /// They're stored as raw bytes to simulate a real queue where serialization
-    /// and deserialization is required.
-    messages: Arc<Mutex<VecDeque<Vec<u8>>>>,
-    /// The number of messages in the queue.
-    num_messages: PollSemaphore,
-    /// The serializer to use for serializing and deserializing messages.
-    serializer: Serializer,
-}
-
-impl InMemoryQueueHandle {
-    pub fn new(serializer: Serializer) -> Self {
-        Self {
-            messages: Default::default(),
-            num_messages: PollSemaphore::new(Arc::new(Semaphore::new(0))),
-            serializer,
-        }
-    }
-}
-
-#[async_trait]
-impl QueueHandle for InMemoryQueueHandle {
-    type Consumer = InMemoryConsumer<Vec<u8>>;
-
-    async fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()> {
-        let mut lock = self.messages.lock().await;
-        lock.push_back(self.serializer.to_bytes(payload)?);
-        self.num_messages.add_permits(1);
-
-        Ok(())
-    }
-
-    async fn declare_consumer(&self, _consumer_name: &str) -> Result<Self::Consumer> {
-        Ok(InMemoryConsumer {
-            messages: self.messages.clone(),
-            num_messages: self.num_messages.clone(),
-            serializer: self.serializer,
-        })
-    }
-}
-
-/// An in-memory implementation of [`Consumer`].
 ///
+/// ## Broadcast Mode
 /// ```
-/// use paladin::{
-///     serializer::Serializer,
-///     acker::Acker,
-///     queue::{Queue, Connection, QueueHandle, Consumer, in_memory::InMemoryQueue}
-/// };
-/// use serde::{Serialize, Deserialize};
-/// use anyhow::Result;
-/// use futures::StreamExt;
-///
+/// # use paladin::{
+/// #     serializer::Serializer,
+/// #     acker::Acker,
+/// #         queue::{Connection,
+/// #         QueueOptions,
+/// #         SyndicationMode,
+/// #         DeliveryMode,
+/// #         QueueHandle,
+/// #         in_memory::InMemoryConnection
+/// #     }
+/// # };
+/// # use serde::{Serialize, Deserialize};
+/// # use anyhow::Result;
+/// # use futures::StreamExt;
+/// #
 /// #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 /// struct MyStruct {
 ///     field: String,
@@ -399,39 +410,84 @@ impl QueueHandle for InMemoryQueueHandle {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<()> {
-///     let queue = InMemoryQueue::new(Serializer::Cbor);
-///     let connection = queue.get_connection().await?;
+///     let connection = InMemoryConnection::new(Serializer::default());
+///
 ///     // Declare a queue
-///     let handle = connection.declare_queue("my_queue").await?;
+///     let handle = connection.declare_queue("my_queue", QueueOptions {
+///         syndication_mode: SyndicationMode::Broadcast,
+///         ..Default::default()
+///     }).await?;
+///
+///     let mut consumer_1 = handle.declare_consumer::<MyStruct>("consumer_1").await?;
+///     let mut consumer_2 = handle.declare_consumer::<MyStruct>("consumer_2").await?;
+///
+///     // Consume the message in the first consumer
+///     let consumer_task_1 = tokio::spawn(async move {
+///         let (message, acker) = consumer_1.next().await.unwrap();
+///         acker.ack().await.unwrap();
+///         message
+///     });
+///
+///     // Consume the message in the second consumer
+///     let consumer_task_2 = tokio::spawn(async move {
+///         let (message, acker) = consumer_2.next().await.unwrap();
+///         acker.ack().await.unwrap();
+///         message
+///     });
 ///
 ///     // Publish a message
 ///     handle.publish(&MyStruct { field: "Hello, World!".to_string() }).await?;
 ///
-///     // Consume the message
-///     let consumer = handle.declare_consumer("my_consumer").await?;
-///     if let Some((message, acker)) = consumer.stream::<MyStruct>().await?.next().await {
-///         acker.ack().await?;
-///         assert_eq!(message, MyStruct { field: "Hello, World!".to_string() });
-///     }
-///     
-///     Ok(())
+///     assert_eq!(consumer_task_1.await.unwrap(), MyStruct { field: "Hello, World!".to_string() });
+///     assert_eq!(consumer_task_2.await.unwrap(), MyStruct { field: "Hello, World!".to_string() });
+/// #
+/// #    Ok(())
 /// }
 /// ```
-///
-/// # Design
-/// The consumer holds a reference to its owning queue's messages and a
-/// [`PollSemaphore`] that is used to synchronize with the queue's message
-/// availability. When the consumer is polled, it will acquire a
-/// permit from the semaphore, which will return pending if no messages are
-/// available. This effectively simulates a message push.
-/// Once a permit is acquired, the consumer will pop a message from the queue
-/// and release the permit, signaling to the queue that a message has been
-/// consumed.
-#[derive(Clone)]
-pub struct InMemoryConsumer<M> {
-    messages: Arc<Mutex<VecDeque<M>>>,
-    serializer: Serializer,
-    num_messages: PollSemaphore,
+#[derive(Clone, Default)]
+pub struct InMemoryQueueHandle {
+    /// The broadcast queue instance.
+    broadcast_queue: BroadcastQueue,
+    /// The exactly once queue instance.
+    exactly_once_queue: ExactlyOnceQueue,
+    /// The queue options.
+    options: QueueOptions,
+}
+
+impl InMemoryQueueHandle {
+    pub fn new(serializer: Serializer, options: QueueOptions) -> Self {
+        Self {
+            options,
+            broadcast_queue: BroadcastQueue::new(options, serializer),
+            exactly_once_queue: ExactlyOnceQueue::new(options, serializer),
+        }
+    }
+}
+
+#[async_trait]
+impl QueueHandle for InMemoryQueueHandle {
+    type Acker = NoopAcker;
+    type Consumer<PayloadTarget: Serializable> = InMemoryConsumer<PayloadTarget>;
+
+    /// Publish a message to the broadcast channel.
+    ///
+    /// This will push the message to all consumers of the broadcast channel.
+    async fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()> {
+        match self.options.syndication_mode {
+            SyndicationMode::ExactlyOnce => self.exactly_once_queue.publish(payload),
+            SyndicationMode::Broadcast => self.broadcast_queue.publish(payload),
+        }
+    }
+
+    async fn declare_consumer<PayloadTarget: Serializable>(
+        &self,
+        consumer_name: &str,
+    ) -> Result<Self::Consumer<PayloadTarget>> {
+        match self.options.syndication_mode {
+            SyndicationMode::ExactlyOnce => self.exactly_once_queue.declare_consumer(consumer_name),
+            SyndicationMode::Broadcast => self.broadcast_queue.declare_consumer(consumer_name),
+        }
+    }
 }
 
 /// A [`Stream`] implementation for [`InMemoryConsumer`].
@@ -442,57 +498,47 @@ pub struct InMemoryConsumer<M> {
 /// will attempt to acquire a lock on the queue's messages. Once the lock is
 /// acquired, the stream will pop a message from the queue and release the
 /// permit, signaling to the queue that a message has been consumed.
-pub struct ConsumerStream<T: Serializable, M> {
+pub struct InMemoryConsumer<T> {
     _marker: std::marker::PhantomData<T>,
-    messages: Arc<Mutex<VecDeque<M>>>,
-    lock_fut: Option<(OwnedMutexLockFuture<VecDeque<M>>, OwnedSemaphorePermit)>,
+    messages: Arc<SegQueue<Bytes>>,
+    permit: Option<OwnedSemaphorePermit>,
     serializer: Serializer,
     num_messages: PollSemaphore,
 }
 
-impl<T: Serializable, M: Deref<Target = [u8]>> Stream for ConsumerStream<T, M> {
+impl<T: Serializable> Stream for InMemoryConsumer<T> {
     type Item = (T, NoopAcker);
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.as_mut();
 
         // If we have a lock future, poll it
-        match this.lock_fut.take() {
-            Some((mut fut, permit)) => {
-                match pin!(&mut fut).poll(cx) {
-                    Poll::Ready(mut lock) => {
-                        // We have a lock, pop the message
-                        let item = lock.pop_front();
-                        // Release the permit, signaling that we've consumed a message
-                        permit.forget();
-                        // Release the lock
-                        drop(lock);
-                        // Clear the lock future
-                        this.lock_fut = None;
+        match this.permit.take() {
+            Some(permit) => {
+                // We have a lock, pop the message
+                let item = this.messages.pop();
+                // Release the permit, signaling that we've consumed a message
+                permit.forget();
+                // Clear the lock future
+                this.permit = None;
 
-                        match item {
-                            Some(item) => {
-                                let item = this
-                                    .serializer
-                                    .from_bytes(&item)
-                                    .expect("failed to deserialize");
+                match item {
+                    Some(item) => {
+                        let item = this
+                            .serializer
+                            .from_bytes(&item)
+                            .expect("failed to deserialize");
 
-                                Poll::Ready(Some((item, NoopAcker::new())))
-                            }
-                            None => {
-                                // Should never happen given that permits should correspond 1:1 to
-                                // messages. Error out so we can debug the logic error.
-                                unreachable!("permit was acquired, but no message was available")
-                            }
-                        }
+                        Poll::Ready(Some((item, NoopAcker::new())))
                     }
-                    // Lock future is not ready
-                    Poll::Pending => {
-                        this.lock_fut = Some((fut, permit));
-                        Poll::Pending
+                    None => {
+                        // Should never happen given that permits should correspond 1:1 to
+                        // messages. Error out so we can debug the logic error.
+                        unreachable!("permit was acquired, but no message was available")
                     }
                 }
             }
+
             // Otherwise, wait for a message
             None => {
                 let permit = ready!(this.num_messages.poll_acquire(cx));
@@ -500,7 +546,7 @@ impl<T: Serializable, M: Deref<Target = [u8]>> Stream for ConsumerStream<T, M> {
                     // If we have a permit, a message should be available
                     Some(permit) => {
                         // Create a lock future and poll ourselves
-                        this.lock_fut = Some((this.messages.clone().lock_owned(), permit));
+                        this.permit = Some(permit);
                         self.poll_next(cx)
                     }
                     None => Poll::Pending,
@@ -510,27 +556,11 @@ impl<T: Serializable, M: Deref<Target = [u8]>> Stream for ConsumerStream<T, M> {
     }
 }
 
-#[async_trait]
-impl<M: Deref<Target = [u8]> + Clone + Send + Sync + 'static> Consumer for InMemoryConsumer<M> {
-    type Acker = NoopAcker;
-    type Stream<T: Serializable> = ConsumerStream<T, M>;
-
-    async fn stream<T: Serializable>(self) -> Result<Self::Stream<T>> {
-        Ok(ConsumerStream {
-            messages: self.messages,
-            serializer: self.serializer,
-            num_messages: self.num_messages,
-            lock_fut: None,
-            _marker: std::marker::PhantomData,
-        })
-    }
-}
-
 #[cfg(test)]
 mod helpers {
     use std::time::Duration;
 
-    use futures::StreamExt;
+    use futures::{Future, StreamExt};
     use serde::{Deserialize, Serialize};
     use tokio::{
         task::{JoinError, JoinHandle},
@@ -542,13 +572,11 @@ mod helpers {
 
     #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
     pub(super) struct Payload {
-        pub(super) field: String,
+        pub(super) field: i64,
     }
 
-    pub(super) fn new_payload(message: &str) -> Payload {
-        Payload {
-            field: message.to_string(),
-        }
+    pub(super) fn new_payload(field: i64) -> Payload {
+        Payload { field }
     }
 
     pub(super) async fn with_timeout<O, F: Future<Output = Result<O, JoinError>>>(
@@ -566,26 +594,20 @@ mod helpers {
         }
     }
 
-    pub(super) fn consume_next<M>(consumer: InMemoryConsumer<M>) -> JoinHandle<Payload>
-    where
-        M: Deref<Target = [u8]> + Clone + Send + Sync + 'static,
-    {
+    pub(super) fn consume_next(mut consumer: InMemoryConsumer<Payload>) -> JoinHandle<Payload> {
         tokio::spawn(async move {
-            let mut stream = consumer.stream::<Payload>().await.unwrap();
-            let (payload, acker) = stream.next().await.unwrap();
+            let (payload, acker) = consumer.next().await.unwrap();
             acker.ack().await.unwrap();
             payload
         })
     }
 
-    pub(super) fn consume_n<M>(consumer: InMemoryConsumer<M>, n: usize) -> JoinHandle<Vec<Payload>>
-    where
-        M: Deref<Target = [u8]> + Clone + Send + Sync + 'static,
-    {
+    pub(super) fn consume_n(
+        consumer: InMemoryConsumer<Payload>,
+        n: usize,
+    ) -> JoinHandle<Vec<Payload>> {
         tokio::spawn(async move {
-            let stream = consumer.stream::<Payload>().await.unwrap();
-
-            stream
+            consumer
                 .then(|(payload, acker)| async move {
                     acker.ack().await.unwrap();
                     payload
@@ -596,17 +618,39 @@ mod helpers {
         })
     }
 
-    pub(super) async fn consumers<H: QueueHandle>(queue: &H) -> (H::Consumer, H::Consumer) {
+    pub(super) fn consume_n_select(
+        c1: InMemoryConsumer<Payload>,
+        c2: InMemoryConsumer<Payload>,
+        n: usize,
+    ) -> JoinHandle<Vec<Payload>> {
+        tokio::spawn(async move {
+            futures::stream::select(c1, c2)
+                .then(|(payload, acker)| async move {
+                    acker.ack().await.unwrap();
+                    payload
+                })
+                .take(n)
+                .collect::<Vec<_>>()
+                .await
+        })
+    }
+
+    pub(super) async fn consumers<P: Serializable, H: QueueHandle>(
+        queue: &H,
+    ) -> (H::Consumer<P>, H::Consumer<P>) {
         try_join!(queue.declare_consumer("1"), queue.declare_consumer("2")).unwrap()
     }
 
-    pub(super) fn publish<H: QueueHandle>(queue: &H, payload: &Payload) -> JoinHandle<Result<()>> {
+    pub(super) fn publish<H: QueueHandle + Send + Sync + 'static>(
+        queue: &H,
+        payload: &Payload,
+    ) -> JoinHandle<Result<()>> {
         let payload = payload.clone();
         let queue = queue.clone();
         tokio::spawn(async move { queue.publish(&payload).await })
     }
 
-    pub(super) fn publish_multi<H: QueueHandle>(
+    pub(super) fn publish_multi<H: QueueHandle + Send + Sync + 'static>(
         queue: &H,
         payload: &[Payload],
     ) -> Vec<JoinHandle<Result<()>>> {
@@ -621,17 +665,27 @@ mod exactly_once {
 
     use super::helpers::*;
     use super::*;
+    use crate::queue::*;
 
     async fn queue_handle() -> InMemoryQueueHandle {
-        let queue = InMemoryQueue::new(Serializer::Cbor);
-        let connection = queue.get_connection().await.unwrap();
-        connection.declare_queue("my_queue").await.unwrap()
+        let connection = InMemoryConnection::new(Serializer::default());
+        connection
+            .declare_queue(
+                "my_queue",
+                QueueOptions {
+                    delivery_mode: DeliveryMode::Persistent,
+                    syndication_mode: SyndicationMode::ExactlyOnce,
+                    durability: QueueDurability::NonDurable,
+                },
+            )
+            .await
+            .unwrap()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn single_message_delivers_once_publish_first() {
         let queue = queue_handle().await;
-        publish(&queue, &new_payload("1"));
+        publish(&queue, &new_payload(1));
 
         let (c1, c2) = consumers(&queue).await;
         let (r1, r2) = (consume_next(c1), consume_next(c2));
@@ -639,8 +693,8 @@ mod exactly_once {
 
         assert!([r1.clone(), r2.clone()].iter().any(|r| r.is_none()));
         assert!([r1.clone(), r2.clone()]
-            .iter()
-            .any(|r| r == &Some(new_payload("1"))));
+            .into_iter()
+            .any(|r| r == Some(new_payload(1))));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
@@ -650,21 +704,21 @@ mod exactly_once {
         let (c1, c2) = consumers(&queue).await;
         let (r1, r2) = (consume_next(c1), consume_next(c2));
 
-        publish(&queue, &new_payload("1"));
+        publish(&queue, &new_payload(1));
 
         let (r1, r2) = join!(with_timeout(r1), with_timeout(r2));
 
         assert!([r1.clone(), r2.clone()].iter().any(|p| p.is_none()));
         assert!([r1.clone(), r2.clone()]
-            .iter()
-            .any(|p| p == &Some(new_payload("1"))));
+            .into_iter()
+            .any(|p| p == Some(new_payload(1))));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn double_message_delivers_once_publish_first() {
         let queue = queue_handle().await;
-        publish(&queue, &new_payload("1"));
-        publish(&queue, &new_payload("2"));
+        publish(&queue, &new_payload(1));
+        publish(&queue, &new_payload(2));
         let (c1, c2) = consumers(&queue).await;
         let (r1, r2) = (consume_next(c1), consume_next(c2));
         let (r1, r2) = try_join!(r1, r2).unwrap();
@@ -678,8 +732,8 @@ mod exactly_once {
 
         let (c1, c2) = consumers(&queue).await;
         let (r1, r2) = (consume_next(c1), consume_next(c2));
-        publish(&queue, &new_payload("1"));
-        publish(&queue, &new_payload("2"));
+        publish(&queue, &new_payload(1));
+        publish(&queue, &new_payload(2));
         let (r1, r2) = try_join!(r1, r2).unwrap();
 
         assert_ne!(r1, r2)
@@ -688,39 +742,58 @@ mod exactly_once {
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn many_messages_single_consumer() {
         let queue = queue_handle().await;
-        let mut payloads = (0..100)
-            .map(|i| new_payload(&i.to_string()))
-            .collect::<Vec<_>>();
+        let payloads = (0..100).map(new_payload).collect::<Vec<_>>();
         publish_multi(&queue, &payloads);
 
         let c = queue.declare_consumer("1").await.unwrap();
         let mut results = consume_n(c, payloads.len()).await.unwrap();
-        payloads.sort_by(|a, b| a.field.cmp(&b.field));
-        results.sort_by(|a, b| a.field.cmp(&b.field));
+        results.sort_by_key(|a| a.field);
+        assert_eq!(payloads, results)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn many_messages_two_consumers() {
+        let queue = queue_handle().await;
+        let payloads = (0..100).map(new_payload).collect::<Vec<_>>();
+        publish_multi(&queue, &payloads);
+
+        let (c1, c2) = consumers(&queue).await;
+        let mut results = consume_n_select(c1, c2, payloads.len()).await.unwrap();
+        results.sort_by_key(|a| a.field);
         assert_eq!(payloads, results)
     }
 }
 
 #[cfg(test)]
 mod broadcast {
-    use tokio::try_join;
+    use tokio::{join, try_join};
 
     use super::helpers::*;
     use super::*;
+    use crate::queue::*;
 
-    async fn broadcast_handle() -> InMemoryBroadcastHandle {
-        let queue = InMemoryQueue::new(Serializer::Cbor);
-        let connection = queue.get_connection().await.unwrap();
-        connection.declare_broadcast("my_queue").await.unwrap()
+    async fn broadcast_handle() -> InMemoryQueueHandle {
+        let connection = InMemoryConnection::new(Serializer::Cbor);
+        connection
+            .declare_queue(
+                "my_broadcast_queue",
+                QueueOptions {
+                    delivery_mode: DeliveryMode::Persistent,
+                    syndication_mode: SyndicationMode::Broadcast,
+                    durability: QueueDurability::NonDurable,
+                },
+            )
+            .await
+            .unwrap()
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn single_message_delivers_to_all_publish_first() {
+    async fn single_message_delivers_to_all_publish_last() {
         let queue = broadcast_handle().await;
-        let expected = new_payload("1");
-        publish(&queue, &expected);
+        let expected = new_payload(1);
 
         let (c1, c2) = consumers(&queue).await;
+        publish(&queue, &expected);
         let (r1, r2) = try_join!(consume_next(c1), consume_next(c2)).unwrap();
 
         assert_eq!(expected, r1);
@@ -728,35 +801,85 @@ mod broadcast {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn many_messages_single_consumer() {
+    async fn single_message_delivers_to_at_least_one_publish_first() {
         let queue = broadcast_handle().await;
-        let mut payloads = (0..100)
-            .map(|i| new_payload(&i.to_string()))
-            .collect::<Vec<_>>();
-        publish_multi(&queue, &payloads);
 
+        publish(&queue, &new_payload(1));
+
+        let (c1, c2) = consumers(&queue).await;
+        let (r1, r2) = (consume_next(c1), consume_next(c2));
+        let (r1, r2) = join!(with_timeout(r1), with_timeout(r2));
+
+        assert!([r1, r2].into_iter().any(|r| r == Some(new_payload(1))));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn many_messages_single_consumer_publish_first() {
+        let queue = broadcast_handle().await;
+        let payloads = (0..5).map(new_payload).collect::<Vec<_>>();
+        publish_multi(&queue, &payloads);
         let c = queue.declare_consumer("1").await.unwrap();
+
         let mut results = consume_n(c, payloads.len()).await.unwrap();
-        payloads.sort_by(|a, b| a.field.cmp(&b.field));
-        results.sort_by(|a, b| a.field.cmp(&b.field));
+        results.sort_by_key(|a| a.field);
+
         assert_eq!(payloads, results)
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
-    async fn many_messages_multi_consumer() {
+    async fn many_messages_single_consumer_publish_last() {
         let queue = broadcast_handle().await;
-        let mut payloads = (0..100)
-            .map(|i| new_payload(&i.to_string()))
-            .collect::<Vec<_>>();
+        let payloads = (0..5).map(new_payload).collect::<Vec<_>>();
+        let c = queue.declare_consumer("1").await.unwrap();
         publish_multi(&queue, &payloads);
 
+        let mut results = consume_n(c, payloads.len()).await.unwrap();
+        results.sort_by_key(|a| a.field);
+
+        assert_eq!(payloads, results)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn many_messages_multi_consumer_publish_first() {
+        let queue = broadcast_handle().await;
+        let payloads = (0..5).map(new_payload).collect::<Vec<_>>();
+        publish_multi(&queue, &payloads);
         let (c1, c2) = consumers(&queue).await;
-        let mut results1 = consume_n(c1, payloads.len()).await.unwrap();
-        let mut results2 = consume_n(c2, payloads.len()).await.unwrap();
-        payloads.sort_by(|a, b| a.field.cmp(&b.field));
-        results1.sort_by(|a, b| a.field.cmp(&b.field));
-        results2.sort_by(|a, b| a.field.cmp(&b.field));
-        assert_eq!(payloads, results1);
-        assert_eq!(payloads, results2)
+
+        let (mut r1, mut r2) = join!(
+            with_timeout(consume_n(c1, payloads.len())),
+            with_timeout(consume_n(c2, payloads.len()))
+        );
+        if let Some(v) = r1.as_mut() {
+            v.sort_by_key(|a| a.field);
+        }
+        if let Some(v) = r2.as_mut() {
+            v.sort_by_key(|a| a.field);
+        }
+        let expected = Some(payloads);
+
+        assert!([r1, r2].into_iter().any(|r| r == expected));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn many_messages_multi_consumer_publish_last() {
+        let queue = broadcast_handle().await;
+        let payloads = (0..5).map(new_payload).collect::<Vec<_>>();
+        let (c1, c2) = consumers(&queue).await;
+        publish_multi(&queue, &payloads);
+
+        let (mut r1, mut r2) = join!(
+            with_timeout(consume_n(c1, payloads.len())),
+            with_timeout(consume_n(c2, payloads.len()))
+        );
+        if let Some(v) = r1.as_mut() {
+            v.sort_by_key(|a| a.field);
+        }
+        if let Some(v) = r2.as_mut() {
+            v.sort_by_key(|a| a.field);
+        }
+        let expected = Some(payloads);
+
+        assert!([r1, r2].into_iter().any(|r| r == expected));
     }
 }

--- a/paladin-core/src/queue/mod.rs
+++ b/paladin-core/src/queue/mod.rs
@@ -13,15 +13,49 @@ use futures::Stream;
 
 use crate::{acker::Acker, serializer::Serializable};
 
-#[async_trait]
-pub trait Queue {
-    /// The type of connection used to interact with the queue.
-    /// Cloning operations should use a resource pool or connection manager to
-    /// ensure cloning is cheap.
-    type Connection: Connection;
+/// The delivery mode of a message.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DeliveryMode {
+    /// A persistent message will be persisted to disk and will survive a broker
+    /// restart if the queue is durable. If the queue is non-durable, the
+    /// message message will be persisted to disk until it is delivered to a
+    /// consumer or until the broker is restarted.
+    #[default]
+    Persistent,
+    /// An ephemeral message will not be persisted to disk and will be lost if
+    /// the broker is restarted.
+    Ephemeral,
+}
 
-    /// Establish a connection to the queue.
-    async fn get_connection(&self) -> Result<Self::Connection>;
+/// The syndication mode of a queue.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum SyndicationMode {
+    /// A single-delivery queue will deliver a message to a single consumer.
+    #[default]
+    ExactlyOnce,
+    /// A broadcast queue will deliver a message to all consumers.
+    Broadcast,
+}
+
+/// The durability of a queue.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum QueueDurability {
+    /// A non-durable queue will be deleted when the broker is restarted.
+    #[default]
+    NonDurable,
+    /// A durable queue will survive a broker restart.
+    Durable,
+}
+
+/// Queue declaration options.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct QueueOptions {
+    /// The message delivery mode.
+    pub delivery_mode: DeliveryMode,
+    /// The syndication mode.
+    pub syndication_mode: SyndicationMode,
+    /// The durability of the queue.
+    pub durability: QueueDurability,
 }
 
 /// A connection to a queue.
@@ -29,17 +63,8 @@ pub trait Queue {
 /// Connections should be cheap to clone such that references need not be passed
 /// around.
 #[async_trait]
-pub trait Connection: Send + Sync + Clone + 'static {
-    /// A single-delivery queue handle.
-    ///
-    /// This should be used for queues whose messages should be delivered
-    /// exactly once.
+pub trait Connection: Clone {
     type QueueHandle: QueueHandle;
-    /// A broadcast queue handle.
-    ///
-    /// This should be used for queues whose messages should be delivered to
-    /// all consumers.
-    type BroadcastHandle: QueueHandle;
 
     /// Close the connection.
     async fn close(&self) -> Result<()>;
@@ -48,26 +73,10 @@ pub trait Connection: Send + Sync + Clone + 'static {
     ///
     /// Queue declaration should be idempotent, in that it should instantiate a
     /// queue if it does not exist, and otherwise return the existing queue.
-    ///
-    /// Queue handles should be used for queues whose messages should be
-    /// delivered exactly once.
-    async fn declare_queue(&self, name: &str) -> Result<Self::QueueHandle>;
+    async fn declare_queue(&self, name: &str, options: QueueOptions) -> Result<Self::QueueHandle>;
 
     /// Delete the queue.
     async fn delete_queue(&self, name: &str) -> Result<()>;
-
-    /// Declare a broadcast queue.
-    ///
-    /// Broadcast queue declaration should be idempotent, in that it should
-    /// instantiate a queue if it does not exist, and otherwise return the
-    /// existing queue.
-    ///
-    /// Broadcast queues should be used for queues whose messages should be
-    /// delivered to all consumers.
-    async fn declare_broadcast(&self, name: &str) -> Result<Self::BroadcastHandle>;
-
-    /// Delete the broadcast queue.
-    async fn delete_broadcast(&self, name: &str) -> Result<()>;
 }
 
 /// A handle to a queue.
@@ -75,8 +84,9 @@ pub trait Connection: Send + Sync + Clone + 'static {
 /// Handles should be cheap to clone such that references need not be passed
 /// around.
 #[async_trait]
-pub trait QueueHandle: Clone + Send + Sync + Unpin + 'static {
-    type Consumer: Consumer;
+pub trait QueueHandle: Clone {
+    type Acker: Acker;
+    type Consumer<T: Serializable>: Stream<Item = (T, Self::Acker)>;
 
     /// Publish a message to the queue.
     ///
@@ -85,23 +95,10 @@ pub trait QueueHandle: Clone + Send + Sync + Unpin + 'static {
     async fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()>;
 
     /// Declare a queue consumer.
-    async fn declare_consumer(&self, consumer_name: &str) -> Result<Self::Consumer>;
-}
-
-/// A queue consumer instance.
-#[async_trait]
-pub trait Consumer: Clone + Send + Sync + Unpin + 'static {
-    type Acker: Acker;
-    type Stream<PayloadTarget: Serializable>: Stream<Item = (PayloadTarget, Self::Acker)>
-        + Send
-        + Sync
-        + Unpin;
-
-    /// Consume messages from the queue as a [`Stream`].
-    ///
-    /// The implementation should take care of deserializing the payload before
-    /// yielding it.
-    async fn stream<PayloadTarget: Serializable>(self) -> Result<Self::Stream<PayloadTarget>>;
+    async fn declare_consumer<PayloadTarget: Serializable>(
+        &self,
+        consumer_name: &str,
+    ) -> Result<Self::Consumer<PayloadTarget>>;
 }
 
 pub mod amqp;

--- a/paladin-core/src/queue/sink.rs
+++ b/paladin-core/src/queue/sink.rs
@@ -9,7 +9,6 @@
 //!
 //! ```no_run
 //! # use paladin::queue::{Connection, QueueOptions, amqp::{AMQPConnection, AMQPConnectionOptions}};
-//! # use paladin::serializer::Serializer;
 //! # use paladin::queue::sink::QueueSink;
 //! # use anyhow::Result;
 //! use serde::{Serialize, Deserialize};
@@ -25,7 +24,7 @@
 //! let conn = AMQPConnection::new(AMQPConnectionOptions {
 //!     uri: "amqp://localhost:5672",
 //!     qos: Some(1),
-//!     serializer: Serializer::Cbor,
+//!     serializer: Default::default(),
 //! }).await?;
 //! let queue = conn.declare_queue("my_queue", QueueOptions::default()).await?;
 //! let mut sink = QueueSink::new(queue);
@@ -77,7 +76,6 @@ impl<Data, Handle> QueueSink<Data, Handle> {
     ///
     /// ```no_run
     /// # use paladin::queue::{Connection, QueueOptions, amqp::{AMQPConnection, AMQPConnectionOptions}};
-    /// # use paladin::serializer::Serializer;
     /// # use paladin::queue::sink::QueueSink;
     /// # use anyhow::Result;
     /// use serde::{Serialize, Deserialize};
@@ -93,7 +91,7 @@ impl<Data, Handle> QueueSink<Data, Handle> {
     /// let conn = AMQPConnection::new(AMQPConnectionOptions {
     ///     uri: "amqp://localhost:5672",
     ///     qos: Some(1),
-    ///     serializer: Serializer::Cbor,
+    ///     serializer: Default::default(),
     /// }).await?;
     /// let queue = conn.declare_queue("my_queue", QueueOptions::default()).await?;
     /// let mut sink = QueueSink::new(queue);

--- a/paladin-core/src/serializer/mod.rs
+++ b/paladin-core/src/serializer/mod.rs
@@ -53,8 +53,9 @@ impl<T> Serializable for T where T: Serialize + DeserializeOwned + Send + Sync +
 /// methods to serialize and deserialize data in different formats.
 /// It can be easily extended to support additional serialization formats in the
 /// future.
-#[derive(Clone, Copy, Serialize, Deserialize, Debug)]
+#[derive(Clone, Copy, Serialize, Deserialize, Debug, Default)]
 pub enum Serializer {
+    #[default]
     Cbor,
 }
 

--- a/paladin-core/src/serializer/mod.rs
+++ b/paladin-core/src/serializer/mod.rs
@@ -56,12 +56,14 @@ impl<T> Serializable for T where T: Serialize + DeserializeOwned + Send + Sync +
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Default)]
 pub enum Serializer {
     #[default]
+    Postcard,
     Cbor,
 }
 
 impl std::fmt::Display for Serializer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Postcard => write!(f, "postcard"),
             Self::Cbor => write!(f, "cbor"),
         }
     }
@@ -72,6 +74,7 @@ impl Serializer {
     #[instrument(skip(value), level = "trace")]
     pub fn to_bytes<T: Serialize>(&self, value: &T) -> Result<Vec<u8>> {
         match self {
+            Self::Postcard => Ok(postcard::to_allocvec(value)?),
             Self::Cbor => {
                 let mut result = Vec::new();
                 ciborium::into_writer(value, &mut result)?;
@@ -85,6 +88,7 @@ impl Serializer {
     #[instrument(skip(bytes), level = "trace")]
     pub fn from_bytes<T: for<'a> Deserialize<'a>>(&self, bytes: &[u8]) -> Result<T> {
         match self {
+            Self::Postcard => Ok(postcard::from_bytes(bytes)?),
             Self::Cbor => Ok(ciborium::from_reader(bytes)?),
         }
     }
@@ -93,6 +97,7 @@ impl Serializer {
 impl From<&Config> for Serializer {
     fn from(config: &Config) -> Self {
         match config.serializer {
+            config::Serializer::Postcard => Self::Postcard,
             config::Serializer::Cbor => Self::Cbor,
         }
     }

--- a/paladin-opkind-derive/Cargo.toml
+++ b/paladin-opkind-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paladin-opkind-derive"
-version = "0.2.0"
+version = "0.3.0"
 description = "Derive macro for paladin."
 license.workspace = true
 edition.workspace = true


### PR DESCRIPTION
This PR introduces new internal plumbing to facilitate interprocess communication between workers. Key highlights include the development of broadcast queues for message propagation and improved failure handling across task routing keys.

# Core changes
## Broadcast queues

- Implemented a new `QueueOptions` as part of the queue abstraction, featuring a `SyndicationMode` option.
- When set to `Broadcast`, messages are propagated to _all_ subscribers, differing from the existing exactly-_once_ delivery mechanism.

## Queue abstraction overhaul

- Simplified the existing queue abstraction by removing two redundant traits.
- This change streamlines the mental model and reduces boilerplate.

## Enhanced in-memory implementation
- Now uses entirely lock free and concurrent data structures, 
    - This not only simplifies the implementation, but significantly improves performance. 
- Resolved a couple deadlock edge-cases and added many more tests for robustness. 
- This new implementation supports both the exactly-once and broadcast syndication modes.

## Operation panic handling

- Operation executions are now caught with `std::panic::catch_unwind` and converted into Paladin fatal operation errors so that they're correctly propagated across the cluster. 

# Task Failure Inter-Process Communication (IPC)

The broadcast queue mode is now used in context of the worker runtime to propagate worker failures to other workers in the cluster. The failure semantics are as such:
1. An operation fails.
2. If transient, the operation is retried according to its configured retry strategy. Once the retry strategy is exhausted, the error is converted into a fatal error.
3. If the error is fatal, an error result is propagated to both the leader process waiting on the associated operation result and the entire cluster of workers over the IPC broadcast channel.
4. Once a sibling worker receives this IPC message, it does two things:
    1. Cancels any currently executing tasks associated to the failed task group (i.e, the routing key).
    2. Temporarily stores that routing key such that any future messages associated to that task group are ignored and nacked.

# Misc
- Added a few helper methods across various implementations and re-organized certain code-paths to have clearer responsibilities and boundaries such that developing within the codebase is overall easier to digest.
- Added [`postcard`](https://crates.io/crates/postcard) binary serialization format. This is _significantly_ faster than cbor or json. This option is still configurable if a human understandable / cross language format is useful for the user, but by default, Paladin will prefer the maximally performant option.