### PR TITLE
Obviate `'static` lifetime `Clone` requirements for operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-opkind-derive"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -353,6 +353,9 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cbc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -990,6 +990,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
+name = "linkme"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ed2ee9464ff9707af8e9ad834cffa4802f072caad90639c583dd3c62e6e608"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125974b109d512fccbc6c0244e7580143e460895dfd6ea7f8bbb692fd94396"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1159,6 +1179,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "lapin",
+ "linkme",
  "num-traits",
  "paladin-opkind-derive",
  "pin-project",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,12 +1996,13 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "rand",
+ "serde",
 ]
 
 [[package]]

--- a/examples/hello-world-rabbitmq/Cargo.lock
+++ b/examples/hello-world-rabbitmq/Cargo.lock
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-core"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-opkind-derive"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "quote",
  "syn",

--- a/examples/hello-world-rabbitmq/Cargo.lock
+++ b/examples/hello-world-rabbitmq/Cargo.lock
@@ -1005,6 +1005,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
+name = "linkme"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ed2ee9464ff9707af8e9ad834cffa4802f072caad90639c583dd3c62e6e608"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba125974b109d512fccbc6c0244e7580143e460895dfd6ea7f8bbb692fd94396"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1173,6 +1193,7 @@ dependencies = [
  "dotenvy",
  "futures",
  "lapin",
+ "linkme",
  "paladin-opkind-derive",
  "pin-project",
  "postcard",

--- a/examples/hello-world-rabbitmq/Cargo.lock
+++ b/examples/hello-world-rabbitmq/Cargo.lock
@@ -353,6 +353,9 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cbc"

--- a/examples/hello-world-rabbitmq/Cargo.lock
+++ b/examples/hello-world-rabbitmq/Cargo.lock
@@ -2009,12 +2009,13 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "rand",
+ "serde",
 ]
 
 [[package]]

--- a/examples/hello-world-rabbitmq/leader/src/main.rs
+++ b/examples/hello-world-rabbitmq/leader/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use dotenvy::dotenv;
-use ops::{CharToString, StringConcat};
+use ops::{register, CharToString, StringConcat};
 use paladin::{
     config::Config,
     directive::{indexed_stream::IndexedStream, Directive},
@@ -23,7 +23,7 @@ async fn main() -> Result<()> {
     init::tracing();
 
     let args = Cli::parse();
-    let runtime = Runtime::from_config(&args.options).await?;
+    let runtime = Runtime::from_config(&args.options, register()).await?;
 
     let input = ['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'];
     let computation = IndexedStream::from(input)

--- a/examples/hello-world-rabbitmq/leader/src/main.rs
+++ b/examples/hello-world-rabbitmq/leader/src/main.rs
@@ -27,8 +27,8 @@ async fn main() -> Result<()> {
 
     let input = ['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', '!'];
     let computation = IndexedStream::from(input)
-        .map(CharToString)
-        .fold(StringConcat);
+        .map(&CharToString)
+        .fold(&StringConcat);
 
     let result = computation.run(&runtime).await;
     runtime.close().await?;

--- a/examples/hello-world-rabbitmq/ops/src/lib.rs
+++ b/examples/hello-world-rabbitmq/ops/src/lib.rs
@@ -1,30 +1,29 @@
-use std::fmt::Debug;
-
 use paladin::{
     operation::{Monoid, Operation, Result},
-    opkind_derive::OpKind,
+    registry, RemoteExecute,
 };
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+registry!();
+
+#[derive(Serialize, Deserialize, RemoteExecute)]
 pub struct CharToString;
 
 impl Operation for CharToString {
     type Input = char;
     type Output = String;
-    type Kind = Ops;
 
     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
         Ok(input.to_string())
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+#[derive(Serialize, Deserialize, RemoteExecute)]
 pub struct StringConcat;
 
 impl Monoid for StringConcat {
     type Elem = String;
-    type Kind = Ops;
+
     fn empty(&self) -> Self::Elem {
         String::new()
     }
@@ -32,10 +31,4 @@ impl Monoid for StringConcat {
     fn combine(&self, a: Self::Elem, b: Self::Elem) -> Result<Self::Elem> {
         Ok(a + &b)
     }
-}
-
-#[derive(OpKind, Debug, Serialize, Deserialize, Clone, Copy)]
-pub enum Ops {
-    CharToString(CharToString),
-    StringConcat(StringConcat),
 }

--- a/examples/hello-world-rabbitmq/worker/src/main.rs
+++ b/examples/hello-world-rabbitmq/worker/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use clap::Parser;
 use dotenvy::dotenv;
-use ops::Ops;
+use ops::register;
 use paladin::{config::Config, runtime::WorkerRuntime};
 
 mod init;
@@ -16,9 +16,10 @@ pub struct Cli {
 async fn main() -> Result<()> {
     dotenv().ok();
     init::tracing();
+
     let args = Cli::parse();
 
-    let runtime: WorkerRuntime<Ops> = WorkerRuntime::from_config(&args.options).await?;
+    let runtime = WorkerRuntime::from_config(&args.options, register()).await?;
     runtime.main_loop().await?;
 
     Ok(())

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -30,7 +30,7 @@ serde = "1.0.183"
 async-trait = "0.1.73"
 ciborium = "0.2.1"
 futures = "0.3.28"
-uuid = { version = "1.4.1", features = ["v4", "fast-rng"] }
+uuid = { version = "1.6.1", features = ["v4", "fast-rng", "serde"] }
 clap = { version = "4.4.2", features = ["derive", "env"] }
 pin-project = "1.1.3"
 thiserror = "1.0.50"

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paladin-core"
-version = "0.3.3"
+version = "0.4.0"
 description = "A Rust distributed algorithm toolkit. Write distributed algorithms without the complexities of distributed systems programming."
 license.workspace = true
 edition.workspace = true

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -39,6 +39,7 @@ dashmap = "5.5.3"
 bytes = "1.5.0"
 crossbeam = "0.8.2"
 postcard = { version = "1.0.8", features = ["alloc"] }
+linkme = "0.3.17"
 
 # Local dependencies
 paladin-opkind-derive = { path = "../paladin-opkind-derive" }

--- a/paladin-core/Cargo.toml
+++ b/paladin-core/Cargo.toml
@@ -36,9 +36,9 @@ pin-project = "1.1.3"
 thiserror = "1.0.50"
 backoff = { version = "0.4.0", features = ["tokio"] }
 dashmap = "5.5.3"
-bytes = "1.5.0"
+bytes = { version = "1.5.0", features = ["std", "serde"] }
 crossbeam = "0.8.2"
-postcard = { version = "1.0.8", features = ["alloc"] }
+postcard = { version = "1.0.8", features = ["use-std"] }
 linkme = "0.3.17"
 
 # Local dependencies

--- a/paladin-core/README.md
+++ b/paladin-core/README.md
@@ -24,9 +24,9 @@ Below is a (contrived) example of how a typical Paladin program looks.
 async fn main() {
     let stream = IndexedStream::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     // Compute the fibonacci number at each element in the stream.
-    let fibs = stream.map(FibAt);
+    let fibs = stream.map(&FibAt);
     // Sum the fibonacci numbers.
-    let sum = fibs.fold(Sum);
+    let sum = fibs.fold(&Sum);
 
     // Run the computation.
     let result = sum.run(&runtime).await.unwrap();

--- a/paladin-core/src/acker.rs
+++ b/paladin-core/src/acker.rs
@@ -79,7 +79,7 @@ use futures::TryFutureExt;
 /// acknowledgement. Implementers of this trait should provide the actual logic
 /// for acknowledging a message in the `ack`  and `nack` methods.
 #[async_trait]
-pub trait Acker: Send + Sync + 'static {
+pub trait Acker: Send + Sync {
     async fn ack(&self) -> Result<()>;
 
     async fn nack(&self) -> Result<()>;

--- a/paladin-core/src/channel/coordinated_channel/coordinated_sink.rs
+++ b/paladin-core/src/channel/coordinated_channel/coordinated_sink.rs
@@ -61,7 +61,7 @@ fn err_closed<T>() -> anyhow::Result<T> {
     bail!(CoordinatedSinkError::SinkClosed)
 }
 
-impl<T: Unpin, Inner: Sink<T, Error = anyhow::Error>> Sink<T> for CoordinatedSink<T, Inner> {
+impl<T, Inner: Sink<T, Error = anyhow::Error>> Sink<T> for CoordinatedSink<T, Inner> {
     type Error = anyhow::Error;
 
     fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {

--- a/paladin-core/src/channel/coordinated_channel/mod.rs
+++ b/paladin-core/src/channel/coordinated_channel/mod.rs
@@ -62,7 +62,7 @@ impl ChannelState {
 /// [`coordinated_channel`] solves these problems by binding the sender and
 /// receiver to a shared state that tracks sender closure and pending sends.
 pub fn coordinated_channel<
-    A: Unpin,
+    A,
     B,
     Sender: Sink<A, Error = anyhow::Error>,
     Receiver: Stream<Item = B>,

--- a/paladin-core/src/channel/mod.rs
+++ b/paladin-core/src/channel/mod.rs
@@ -43,17 +43,17 @@ pub enum ChannelType {
 /// is needed.
 #[async_trait]
 pub trait Channel {
-    type Sender<T: Serializable>: Sink<T>;
+    type Sender<'a, T: Serializable + 'a>: Sink<T>;
     type Acker: Acker;
-    type Receiver<T: Serializable>: Stream<Item = (T, Self::Acker)>;
+    type Receiver<'a, T: Serializable + 'a>: Stream<Item = (T, Self::Acker)>;
 
     async fn close(&self) -> Result<()>;
 
     /// Acquire the sender side of the channel.
-    async fn sender<T: Serializable>(&self) -> Result<Self::Sender<T>>;
+    async fn sender<'a, T: Serializable + 'a>(&self) -> Result<Self::Sender<'a, T>>;
 
     /// Acquire the receiver side of the channel.
-    async fn receiver<T: Serializable>(&self) -> Result<Self::Receiver<T>>;
+    async fn receiver<'a, T: Serializable + 'a>(&self) -> Result<Self::Receiver<'a, T>>;
 
     /// Mark the channel for release.
     fn release(&self);

--- a/paladin-core/src/channel/mod.rs
+++ b/paladin-core/src/channel/mod.rs
@@ -20,6 +20,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::{Sink, Stream};
 use pin_project::{pin_project, pinned_drop};
+use uuid::Uuid;
 
 use crate::{acker::Acker, serializer::Serializable};
 
@@ -69,11 +70,11 @@ pub trait ChannelFactory {
 
     /// Retrieve an existing channel. An identifier is provided when a channel
     /// is issued.
-    async fn get(&self, identifier: &str, channel_type: ChannelType) -> Result<Self::Channel>;
+    async fn get(&self, identifier: Uuid, channel_type: ChannelType) -> Result<Self::Channel>;
 
     /// Issue a new channel. An identifier is returned which can be used to
     /// retrieve the channel later in some other process.
-    async fn issue(&self, channel_type: ChannelType) -> Result<(String, Self::Channel)>;
+    async fn issue(&self, channel_type: ChannelType) -> Result<(Uuid, Self::Channel)>;
 }
 
 /// Guard a channel and embed a particular pipe in the lease guard.

--- a/paladin-core/src/channel/queue.rs
+++ b/paladin-core/src/channel/queue.rs
@@ -146,8 +146,8 @@ impl<
     > Channel for QueueChannel<Conn>
 {
     type Acker = <QHandle as QueueHandle>::Acker;
-    type Sender<T: Serializable> = QueueSink<T, QHandle>;
-    type Receiver<T: Serializable> = <QHandle as QueueHandle>::Consumer<T>;
+    type Sender<'a, T: Serializable + 'a> = QueueSink<'a, T, QHandle>;
+    type Receiver<'a, T: Serializable + 'a> = <QHandle as QueueHandle>::Consumer<T>;
 
     /// Close the underlying connection.
     async fn close(&self) -> Result<()> {
@@ -156,7 +156,7 @@ impl<
     }
 
     /// Get a sender for the underlying queue.
-    async fn sender<T: Serializable>(&self) -> Result<Self::Sender<T>> {
+    async fn sender<'a, T: Serializable + 'a>(&self) -> Result<Self::Sender<'a, T>> {
         let queue = self
             .connection
             .declare_queue(&self.identifier, self.channel_type.into())
@@ -165,7 +165,7 @@ impl<
     }
 
     /// Get a receiver for the underlying queue.
-    async fn receiver<T: Serializable>(&self) -> Result<Self::Receiver<T>> {
+    async fn receiver<'a, T: Serializable + 'a>(&self) -> Result<Self::Receiver<'a, T>> {
         let queue = self
             .connection
             .declare_queue(&self.identifier, self.channel_type.into())

--- a/paladin-core/src/channel/queue.rs
+++ b/paladin-core/src/channel/queue.rs
@@ -15,6 +15,7 @@
 //!     queue::{Connection, amqp::{AMQPConnection, AMQPConnectionOptions}},
 //!     channel::{Channel, ChannelType, ChannelFactory, queue::QueueChannelFactory},
 //! };
+//! use uuid::Uuid;
 //! use serde::{Serialize, Deserialize};
 //! use anyhow::Result;
 //! use futures::SinkExt;
@@ -36,7 +37,7 @@
 //!     // Build the factory
 //!     let amqp_channel_factory = QueueChannelFactory::new(conn);
 //!     // Get a channel
-//!     let channel = amqp_channel_factory.get("my_queue", ChannelType::ExactlyOnce).await?;
+//!     let (_, channel) = amqp_channel_factory.issue(ChannelType::ExactlyOnce).await?;
 //!     // Get a sender pipe
 //!     let mut sender = channel.sender::<MyStruct>().await?;
 //!     // Dispatch a message
@@ -74,7 +75,7 @@
 //!     // Build the factory
 //!     let amqp_channel_factory = QueueChannelFactory::new(conn);
 //!     // Get a channel
-//!     let channel = amqp_channel_factory.get("my_queue", ChannelType::ExactlyOnce).await?;
+//!     let (_, channel) = amqp_channel_factory.issue(ChannelType::ExactlyOnce).await?;
 //!     // Get a receiver pipe
 //!     let mut receiver = channel.receiver::<MyStruct>().await?;
 //!     // Receive messages
@@ -135,7 +136,7 @@ impl<Conn> QueueChannelFactory<Conn> {
 #[derive(Clone)]
 pub struct QueueChannel<Conn> {
     connection: Conn,
-    identifier: String,
+    identifier: Uuid,
     channel_type: ChannelType,
 }
 
@@ -159,7 +160,12 @@ impl<
     async fn sender<'a, T: Serializable + 'a>(&self) -> Result<Self::Sender<'a, T>> {
         let queue = self
             .connection
-            .declare_queue(&self.identifier, self.channel_type.into())
+            .declare_queue(
+                self.identifier
+                    .as_simple()
+                    .encode_lower(&mut Uuid::encode_buffer()),
+                self.channel_type.into(),
+            )
             .await?;
         Ok(QueueSink::new(queue))
     }
@@ -168,7 +174,12 @@ impl<
     async fn receiver<'a, T: Serializable + 'a>(&self) -> Result<Self::Receiver<'a, T>> {
         let queue = self
             .connection
-            .declare_queue(&self.identifier, self.channel_type.into())
+            .declare_queue(
+                self.identifier
+                    .as_simple()
+                    .encode_lower(&mut Uuid::encode_buffer()),
+                self.channel_type.into(),
+            )
             .await?;
         let consumer = queue.declare_consumer(&Uuid::new_v4().to_string()).await?;
 
@@ -178,9 +189,12 @@ impl<
     /// Delete the underlying queue.
     fn release(&self) {
         let conn = self.connection.clone();
-        let identifier = self.identifier.clone();
+        let identifier = self.identifier;
+
         tokio::spawn(async move {
-            _ = conn.delete_queue(&identifier).await;
+            let buffer = &mut Uuid::encode_buffer();
+            let identifier = identifier.as_simple().encode_lower(buffer);
+            _ = conn.delete_queue(identifier).await;
         });
     }
 }
@@ -193,19 +207,19 @@ where
     type Channel = QueueChannel<Conn>;
 
     /// Get an existing channel.
-    async fn get(&self, identifier: &str, channel_type: ChannelType) -> Result<Self::Channel> {
+    async fn get(&self, identifier: Uuid, channel_type: ChannelType) -> Result<Self::Channel> {
         Ok(QueueChannel {
             connection: self.connection.clone(),
-            identifier: identifier.to_string(),
+            identifier,
             channel_type,
         })
     }
 
     /// Issue a new channel, generating a new UUID as the identifier.
-    async fn issue(&self, channel_type: ChannelType) -> Result<(String, Self::Channel)> {
-        let identifier = Uuid::new_v4().to_string();
+    async fn issue(&self, channel_type: ChannelType) -> Result<(Uuid, Self::Channel)> {
+        let identifier = Uuid::new_v4();
         Ok((
-            identifier.clone(),
+            identifier,
             QueueChannel {
                 connection: self.connection.clone(),
                 identifier,

--- a/paladin-core/src/config/mod.rs
+++ b/paladin-core/src/config/mod.rs
@@ -19,17 +19,11 @@
 
 use clap::{Args, ValueEnum};
 
-const DEFAULT_TASK_ROUTING_KEY: &str = "task";
 const HELP_HEADING: &str = "Paladin options";
 
 /// Represents the main configuration structure for the runtime.
-#[derive(Args, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[derive(Args, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
 pub struct Config {
-    /// Specifies the routing key for publishing task messages. In most cases,
-    /// the default value should suffice.
-    #[arg(long, short, help_heading = HELP_HEADING, default_value = DEFAULT_TASK_ROUTING_KEY)]
-    pub task_bus_routing_key: String,
-
     /// Determines the serialization format to be used.
     #[arg(long, short, help_heading = HELP_HEADING, value_enum, default_value_t = Serializer::Postcard)]
     pub serializer: Serializer,
@@ -40,24 +34,12 @@ pub struct Config {
 
     /// Specifies the number of worker threads to spawn (in memory runtime
     /// only).
-    #[arg(long, short, help_heading = HELP_HEADING,)]
+    #[arg(long, short, help_heading = HELP_HEADING)]
     pub num_workers: Option<usize>,
 
     /// Provides the URI for the AMQP broker, if the AMQP runtime is selected.
     #[arg(long, help_heading = HELP_HEADING, env = "AMQP_URI", required_if_eq("runtime", "amqp"))]
     pub amqp_uri: Option<String>,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            task_bus_routing_key: DEFAULT_TASK_ROUTING_KEY.to_string(),
-            serializer: Default::default(),
-            runtime: Default::default(),
-            num_workers: Default::default(),
-            amqp_uri: Default::default(),
-        }
-    }
 }
 
 /// Enumerates the available serialization formats.

--- a/paladin-core/src/directive/indexed_stream/foldable.rs
+++ b/paladin-core/src/directive/indexed_stream/foldable.rs
@@ -56,7 +56,8 @@ impl<Op: Operation> Contiguous for TaskOutput<Op, Metadata> {
     }
 }
 
-type Sender<Op> = Box<dyn Sink<Task<Op, Metadata>, Error = anyhow::Error> + Send + Unpin>;
+type Sender<'a, Op> =
+    Box<dyn Sink<Task<'a, Op, Metadata>, Error = anyhow::Error> + Send + Unpin + 'a>;
 
 /// A [`Dispatcher`] abstracts over the common functionality of queuing and
 /// dispatching contiguous [`Task`]s to worker processes.
@@ -69,19 +70,22 @@ type Sender<Op> = Box<dyn Sink<Task<Op, Metadata>, Error = anyhow::Error> + Send
 /// - Dequeuing [`TaskResult`]s.
 /// - Attempting to dispatch [`TaskResult`]s if they are contiguous with another
 ///   [`TaskResult`].
-struct Dispatcher<Op: Monoid> {
+struct Dispatcher<'a, Op: Monoid> {
+    op: &'a Op,
     assembler: Arc<Mutex<ContiguousQueue<TaskOutput<Op, Metadata>>>>,
-    sender: Arc<Mutex<Sender<Op>>>,
+    sender: Arc<Mutex<Sender<'a, Op>>>,
     channel_identifier: String,
 }
 
-impl<Op: Monoid> Dispatcher<Op> {
+impl<'a, Op: Monoid> Dispatcher<'a, Op> {
     fn new(
+        op: &'a Op,
         assembler: Arc<Mutex<ContiguousQueue<TaskOutput<Op, Metadata>>>>,
-        sender: Arc<Mutex<Sender<Op>>>,
+        sender: Arc<Mutex<Sender<'a, Op>>>,
         channel_identifier: String,
     ) -> Self {
         Self {
+            op,
             assembler,
             sender,
             channel_identifier,
@@ -113,7 +117,7 @@ impl<Op: Monoid> Dispatcher<Op> {
                 metadata: Metadata {
                     range: *lhs.metadata.range.start()..=*rhs.metadata.range.end(),
                 },
-                op: lhs.op.clone(),
+                op: self.op,
                 input: (lhs.output, rhs.output),
             };
             let mut sender = self.sender.lock().await;
@@ -125,11 +129,11 @@ impl<Op: Monoid> Dispatcher<Op> {
 }
 
 #[async_trait]
-impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
-    async fn f_fold<M: Monoid<Elem = A>>(self, m: M, runtime: &Runtime) -> Result<A> {
-        let (channel_identifier, sender, mut receiver) = runtime
-            .lease_coordinated_task_channel::<M, Metadata>()
-            .await?;
+impl<'a, A: Send + 'a, B: Send + 'a> Foldable<'a, B> for IndexedStream<'a, A> {
+    async fn f_fold<M: Monoid<Elem = A>>(self, m: &'a M, runtime: &Runtime) -> Result<A> {
+        let (channel_identifier, sender, mut receiver) =
+            runtime.lease_coordinated_task_channel().await?;
+
         // mutable access to the assembler. So we wrap it in an Arc<Mutex<>>.
         let assembler = Arc::new(Mutex::new(ContiguousQueue::new()));
         // Both the initialization step and the result stream need to asynchronous
@@ -137,6 +141,7 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
         let sender = Arc::new(Mutex::new(sender));
         // Initialize the dispatcher.
         let dispatcher = Arc::new(Dispatcher::new(
+            m,
             assembler.clone(),
             sender.clone(),
             channel_identifier.clone(),
@@ -165,7 +170,6 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
         // of the job by tallying the number of inputs.
         let init = self
             .try_fold(0, |sum, (idx, item)| {
-                let op = m.clone();
                 let dispatcher = dispatcher.clone();
                 let should_dispatch = should_dispatch.clone();
 
@@ -175,7 +179,6 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
                     // Because this represents an uncombined input, we set the
                     // range equal to its index.
                     let item_result = TaskOutput {
-                        op,
                         metadata: Metadata { range: idx..=idx },
                         output: item,
                     };
@@ -187,7 +190,7 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
                     } else {
                         // Now that we've seen at least two inputs, we can start dispatching.
                         // Notify the result stream that it can start consuming.
-                        should_dispatch.notify_waiters();
+                        should_dispatch.notify_one();
                         // Dispatch the task.
                         dispatcher.try_dispatch(item_result).await?;
                     }
@@ -204,11 +207,10 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
                 Ok::<_, anyhow::Error>(size)
             });
 
-        let result_handle = tokio::spawn({
+        let result_handle = {
             let resolved_input_size = resolved_input_size.clone();
             let dispatcher = dispatcher.clone();
             let should_dispatch = should_dispatch.clone();
-            let op = m.clone();
 
             async move {
                 // Wait until at least two inputs have been received.
@@ -218,8 +220,9 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
                     let result = result?;
                     // Check to see if the input size is known.
                     if let Some(job_size) = *resolved_input_size.read().await {
-                        // If it is, we can check to see if the result is the final result (i.e.,
-                        // its range comprises the size of the input).
+                        // If it is, we can check to see if the result is the final result
+                        // (i.e., its range comprises the size of
+                        // the input).
                         if result.is_final(job_size) {
                             sender.lock().await.close().await?;
                             return Ok(result.output);
@@ -230,21 +233,17 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
                     acker.ack().await?;
                 }
 
-                Ok(op.empty())
+                Ok(m.empty())
             }
-        });
+        };
 
         let size = init.await?;
         match size {
             0 => {
-                // Abort the result handle, as it will never receive a result.
-                result_handle.abort();
                 // If the input is empty, we return the empty element.
                 return Ok(m.empty());
             }
             1 => {
-                // Abort the result handle, as it will never receive a result.
-                result_handle.abort();
                 // If the input has a single element, we return it.
                 // The dispatcher is guaranteed to have queued the single input element at this
                 // point, so we can safely dequeue it. If it doesn't, this is a
@@ -258,6 +257,6 @@ impl<A: Send + 'static, B: Send + 'static> Foldable<B> for IndexedStream<A> {
             _ => {}
         }
 
-        result_handle.await?
+        result_handle.await
     }
 }

--- a/paladin-core/src/directive/indexed_stream/functor.rs
+++ b/paladin-core/src/directive/indexed_stream/functor.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::{FutureExt, SinkExt, StreamExt, TryStreamExt};
+use futures::{SinkExt, StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
 
 use super::IndexedStream;
@@ -18,50 +18,34 @@ struct Metadata {
 }
 
 #[async_trait]
-impl<A: Send + 'static, B: Send + 'static> Functor<B> for IndexedStream<A> {
-    async fn f_map<Op: Operation<Input = A, Output = B>>(
-        mut self,
-        op: Op,
-        runtime: &Runtime,
-    ) -> Result<Self::Target> {
-        let (channel_identifier, mut sender, receiver) = runtime
-            .lease_coordinated_task_channel::<Op, Metadata>()
-            .await?;
+impl<'a, A: Send + 'a, B: Send + 'a> Functor<'a, B> for IndexedStream<'a, A> {
+    async fn f_map<Op: Operation>(self, op: &'a Op, runtime: &Runtime) -> Result<Self::Target>
+    where
+        Op: Operation<Input = A, Output = B>,
+    {
+        let (channel_identifier, mut sender, receiver) =
+            runtime.lease_coordinated_task_channel().await?;
 
-        // Dispatch tasks in a thread to avoid blocking until all input is received.
-        // This way we can process results as they come in.
-        let sender_fut = tokio::spawn(async move {
+        // Place the sending task into a stream so that it can be combined with the
+        // output stream with `select`. This will allow us to forward any errors that
+        // occur while sending tasks to the output stream; any errors that occur
+        // while sending tasks means that the entire operation should fail, as
+        // the output stream will be incomplete.
+        let sender_stream = futures::stream::once(async move {
             let mut task_stream = self.map_ok(|(idx, input)| Task {
                 routing_key: channel_identifier.clone(),
                 metadata: Metadata { idx },
-                op: op.clone(),
+                op,
                 input,
             });
 
             sender.send_all(&mut task_stream).await?;
             sender.close().await?;
             Ok::<(), anyhow::Error>(())
-        });
-
-        // Convert the sender thread into a stream so that we can combine it with the
-        // output stream. This will allow us to forward any errors that occur
-        // while sending tasks to the output stream; any errors that occur while
-        // sending tasks means that the entire operation should fail, as the
-        // output stream will be incomplete.
-        let sender_stream = sender_fut.into_stream().filter_map(|result| {
-            Box::pin(async move {
-                match result {
-                    // We're only interested in errors, as the sender thread will
-                    // only return an error if it fails to send a task.
-                    Ok(Ok(())) => None,
-                    // If the sender thread returns an error, we want to forward
-                    // it to the output stream.
-                    Ok(Err(e)) => Some(Err(e)),
-                    // If the sender thread panics, we want to forward the panic
-                    // to the output stream.
-                    Err(e) => Some(Err(anyhow::Error::from(e))),
-                }
-            })
+        })
+        .filter_map(|result| async move {
+            // Ignore successful results, while forwarding errors.
+            result.err().map(Err)
         });
 
         let result_stream = receiver.then(move |(result, acker)| {

--- a/paladin-core/src/directive/indexed_stream/functor.rs
+++ b/paladin-core/src/directive/indexed_stream/functor.rs
@@ -33,7 +33,7 @@ impl<'a, A: Send + 'a, B: Send + 'a> Functor<'a, B> for IndexedStream<'a, A> {
         // the output stream will be incomplete.
         let sender_stream = futures::stream::once(async move {
             let mut task_stream = self.map_ok(|(idx, input)| Task {
-                routing_key: channel_identifier.clone(),
+                routing_key: channel_identifier,
                 metadata: Metadata { idx },
                 op,
                 input,

--- a/paladin-core/src/directive/literal/mod.rs
+++ b/paladin-core/src/directive/literal/mod.rs
@@ -5,34 +5,28 @@
 /// ## Example
 /// ```
 /// # use paladin::{
+/// #    RemoteExecute,
 /// #    operation::{Operation, Result},
 /// #    directive::{Directive, Literal},
-/// #    opkind_derive::OpKind,
 /// #    runtime::Runtime,
 /// # };
 /// # use serde::{Deserialize, Serialize};
 /// #
-/// # #[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+/// # #[derive(Deserialize, Serialize, RemoteExecute)]
 /// struct MultiplyBy(i32);
 /// impl Operation for MultiplyBy {
 ///     type Input = i32;
 ///     type Output = i32;
-///     type Kind = MyOps;
 ///
 ///     fn execute(&self, input: i32) -> Result<i32> {
 ///         Ok(self.0 * input)
 ///     }
 /// }
-/// #
-/// # #[derive(OpKind, Copy, Clone, Debug, Deserialize, Serialize)]
-/// # enum MyOps {
-/// #    MultiplyBy(MultiplyBy),
-/// # }
 ///
 /// # #[tokio::main]
 /// # async fn main() -> anyhow::Result<()> {
 /// # let runtime = Runtime::in_memory().await?;
-/// let computation = Literal(5).map(MultiplyBy(2));
+/// let computation = Literal(5).map(&MultiplyBy(2));
 /// let result = computation.run(&runtime).await?;
 /// assert_eq!(result, Literal(10));
 /// # Ok(())

--- a/paladin-core/src/lib.rs
+++ b/paladin-core/src/lib.rs
@@ -53,17 +53,15 @@
 //! [`Directive`](crate::directive::Directive)s and remotely executed.
 //!
 //! ```
-//! use paladin::operation::{Operation, Result};
-//! # use paladin::opkind_derive::OpKind;
+//! use paladin::{RemoteExecute, operation::{Operation, Result}};
 //! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+//! #[derive(Serialize, Deserialize, RemoteExecute)]
 //! struct FibAt;
 //!
 //! impl Operation for FibAt {
 //!     type Input = u64;
 //!     type Output = u64;
-//! #    type Kind = MyOps;
 //!   
 //!     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
 //!         match input {
@@ -83,62 +81,9 @@
 //!     }
 //! }
 //!
-//! # #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! # enum MyOps {
-//! #   FibAt(FibAt),
-//! # }
 //! # fn main() {
 //! assert_eq!(FibAt.execute(10).unwrap(), 55);
 //! # }
-//! ```
-//!
-//! ### Operation Registry
-//!
-//! To enable remote machines to execute your operations, you must declare a
-//! registry of all available operations. This ensures remote executors can
-//! deserialize and execute them correctly. Paladin provides a macro that wires
-//! up all the necessary machinery on your registry. Registries must be declared
-//! as an enum where the variants are single tuple structs containing the
-//! operation.
-//!
-//! ```
-//! use paladin::{operation::{Operation, Result}, opkind_derive::OpKind};
-//! use serde::{Deserialize, Serialize};
-//!
-//! #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
-//! struct FibAt;
-//!
-//! impl Operation for FibAt {
-//!     // ...
-//! #    type Input = u64;
-//! #    type Output = u64;
-//!     // Associate the operation with the registry type.
-//!     type Kind = MyOps;
-//!     // ...
-//! #  
-//! #    fn execute(&self, input: Self::Input) -> Result<Self::Output> {
-//! #        match input {
-//! #            0 => Ok(0),
-//! #            1 => Ok(1),
-//! #            _ => {
-//! #                let mut a = 0;
-//! #                let mut b = 1;
-//! #                for _ in 2..=input {
-//! #                    let temp = a;
-//! #                    a = b;
-//! #                    b = temp + b;
-//! #                }
-//! #                Ok(b)
-//! #            }
-//! #        }
-//! #    }
-//! }
-//!
-//! // Declare the registry.
-//! #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! enum MyOps {
-//!     FibAt(FibAt),
-//! }
 //! ```
 //!
 //! ## Constructing a program
@@ -148,16 +93,15 @@
 //! program.
 //!
 //! ```
-//! # use paladin::{operation::{Operation, Result}, opkind_derive::OpKind};
-//! # use serde::{Deserialize, Serialize};
+//! use paladin::{RemoteExecute, operation::{Operation, Result}};
+//! use serde::{Deserialize, Serialize};
 //! #
-//! # #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+//! # #[derive(Serialize, Deserialize, RemoteExecute)]
 //! # struct FibAt;
 //! #
 //! # impl Operation for FibAt {
 //! #    type Input = u64;
 //! #    type Output = u64;
-//! #    type Kind = MyOps;
 //! #  
 //! #    fn execute(&self, input: Self::Input) -> Result<Self::Output> {
 //! #        match input {
@@ -177,12 +121,6 @@
 //! #    }
 //! # }
 //! #
-//! # #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! # enum MyOps {
-//! #    FibAt(FibAt),
-//! #    Sum(Sum),
-//! # }
-//! #
 //! use paladin::{
 //!     operation::Monoid,
 //!     directive::{indexed_stream::IndexedStream, Directive},
@@ -190,11 +128,11 @@
 //! };
 //!
 //! // Define a Sum monoid.
-//! # #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+//! #[derive(Serialize, Deserialize, RemoteExecute)]
 //! struct Sum;
+//!
 //! impl Monoid for Sum {
 //!     type Elem = u64;
-//!     type Kind = MyOps;
 //!
 //!     fn combine(&self, a: Self::Elem, b: Self::Elem) -> Result<Self::Elem> {
 //!        Ok(a + b)
@@ -207,13 +145,13 @@
 //!
 //! #[tokio::main]
 //! async fn main() -> anyhow::Result<()> {
-//!     let runtime = Runtime::in_memory().await.unwrap();
+//!     let runtime = Runtime::in_memory().await?;
 //!     let stream = IndexedStream::from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
 //!     // Compute the fibonacci number at each element in the stream with our
 //!     // previously declared `FibAt` operation.
-//!     let fibs = stream.map(FibAt);
+//!     let fibs = stream.map(&FibAt);
 //!     // Sum the fibonacci numbers.
-//!     let sum = fibs.fold(Sum);
+//!     let sum = fibs.fold(&Sum);
 //!
 //!     // Run the computation.
 //!     let result = sum.run(&runtime).await;
@@ -278,9 +216,25 @@ pub mod queue;
 pub mod runtime;
 pub mod serializer;
 pub mod task;
-pub mod opkind_derive {
-    pub use paladin_opkind_derive::*;
-}
 pub use async_trait::async_trait;
-pub use futures;
-pub use tracing;
+pub use paladin_opkind_derive::*;
+
+// Not public API. Used by generated code.
+#[doc(hidden)]
+pub mod __private {
+    #[doc(hidden)]
+    pub use futures;
+    #[doc(hidden)]
+    pub use linkme;
+    #[doc(hidden)]
+    pub use tracing;
+
+    #[doc(hidden)]
+    #[linkme::distributed_slice]
+    pub static OPERATIONS: [fn(
+        crate::task::AnyTask,
+    ) -> futures::future::BoxFuture<
+        'static,
+        crate::operation::Result<crate::task::AnyTaskOutput>,
+    >];
+}

--- a/paladin-core/src/lib.rs
+++ b/paladin-core/src/lib.rs
@@ -227,6 +227,8 @@ pub mod __private {
     #[doc(hidden)]
     pub use linkme;
     #[doc(hidden)]
+    pub use tokio;
+    #[doc(hidden)]
     pub use tracing;
 
     #[doc(hidden)]

--- a/paladin-core/src/lib.rs
+++ b/paladin-core/src/lib.rs
@@ -223,6 +223,8 @@ pub use paladin_opkind_derive::*;
 #[doc(hidden)]
 pub mod __private {
     #[doc(hidden)]
+    pub use bytes;
+    #[doc(hidden)]
     pub use futures;
     #[doc(hidden)]
     pub use linkme;

--- a/paladin-core/src/operation/error.rs
+++ b/paladin-core/src/operation/error.rs
@@ -317,8 +317,7 @@ pub enum FatalStrategy {
 /// #[tokio::main]
 /// async fn main() -> anyhow::Result<()> {
 /// # let runtime = Runtime::in_memory().await?;
-///     let op = Multiply::default();
-///     let computation = IndexedStream::from([1, 2, 3]).fold(&op);
+///     let computation = IndexedStream::from([1, 2, 3]).fold(&Multiply);
 ///     let result = computation.run(&runtime).await?;
 ///
 ///     assert_eq!(result, 6);
@@ -376,16 +375,10 @@ pub enum FatalStrategy {
 /// #[tokio::main]
 /// async fn main() -> anyhow::Result<()> {
 /// # let runtime = Runtime::in_memory().await?;
-///     let op = Multiply::default();
-///     let computation = IndexedStream::from([1, 2, 3]).fold(&op);
+///     let computation = IndexedStream::from([1, 2, 3]).fold(&Multiply);
 ///     let result = computation.run(&runtime).await;
 ///
-///     let expected = format!(
-///         "Fatal operation error: tried {}/{}",
-///         MAX_TRIES + 1,
-///         MAX_TRIES + 1
-///     );
-///     assert_eq!(result.unwrap_err().to_string(), expected);
+///     assert_eq!(NUM_TRIES.load(Ordering::SeqCst), MAX_TRIES + 2);
 /// # Ok(())
 /// }
 #[derive(Error, Debug)]

--- a/paladin-core/src/operation/mod.rs
+++ b/paladin-core/src/operation/mod.rs
@@ -90,6 +90,8 @@
 //! ```
 use std::fmt::Debug;
 
+use bytes::Bytes;
+
 use crate::serializer::{Serializable, Serializer};
 
 /// An operation that is identifiable and executable by the runtime in a
@@ -125,21 +127,21 @@ pub trait Operation: RemoteExecute + Serializable {
     }
 
     /// Get a byte representation of the output.
-    fn output_to_bytes(&self, serializer: Serializer, output: Self::Output) -> Result<Vec<u8>> {
+    fn output_to_bytes(&self, serializer: Serializer, output: Self::Output) -> Result<Bytes> {
         Ok(serializer
             .to_bytes(&output)
             .map_err(|err| FatalError::from_anyhow(err, Default::default()))?)
     }
 
     /// Execute the operation on the given input as bytes.
-    fn execute_as_bytes(&self, serializer: Serializer, input: &[u8]) -> Result<Vec<u8>> {
+    fn execute_as_bytes(&self, serializer: Serializer, input: &[u8]) -> Result<Bytes> {
         self.input_from_bytes(serializer, input)
             .and_then(|input| self.execute(input))
             .and_then(|output| self.output_to_bytes(serializer, output))
     }
 
     /// Get a byte representation of the operation.
-    fn as_bytes(&self, serializer: Serializer) -> Result<Vec<u8>> {
+    fn as_bytes(&self, serializer: Serializer) -> Result<Bytes> {
         let output = serializer
             .to_bytes(self)
             .map_err(|err| FatalError::from_anyhow(err, Default::default()))?;

--- a/paladin-core/src/operation/mod.rs
+++ b/paladin-core/src/operation/mod.rs
@@ -20,24 +20,6 @@
 //! is provided. An [`Operation`] is strictly more general than a [`Monoid`], so
 //! we can trivially derive an [`Operation`] for every [`Monoid`].
 //!
-//! ## [`OpKind`]
-//! A trait used to create a registry of all available operations.It's used to
-//! facilitate serialization, deserialization, and remote dynamic execution of
-//! operations.
-//!
-//! # Notes
-//!
-//! - Operations are monomorphic over their implementing type. This is
-//!   illustrated by the fact that the `Input` and `Output` types are
-//!   _associated_ types of the [`Operation`] trait. This obviates the need to
-//!   make [`OpKind`] enums generic and thus simplifies downstream code by
-//!   removing the need for threading generic parameters through the system. It
-//!   is, however, possible to implement [`Operation`]s for generic types. see
-//!   the [example](#defining-a-polymorphic-monoid). They just must be
-//!   monomorphized in the enum definition. It is not yet clear that
-//!   polymorphism at the level of [`OpKind`] needed. This may change as the
-//!   system sees more use, in which case we can revisit this design decision.
-//!
 //! # Usage:
 //! Operations are the semantic building blocks of the system. They define what
 //! computations can be performed by the system. By implementing the
@@ -50,40 +32,33 @@
 //! ### Defining an [`Operation`]:
 //!
 //! ```
-//! use paladin::{operation::{Operation, Result}, opkind_derive::OpKind};
+//! use paladin::{RemoteExecute, operation::{Operation, Result}};
 //! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+//! #[derive(Serialize, Deserialize, RemoteExecute)]
 //! struct StringLength;
 //!
 //! impl Operation for StringLength {
 //!     type Input = String;
 //!     type Output = usize;
-//!     type Kind = MyOps;
 //!     
 //!     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
 //!         Ok(input.len())
 //!     }
-//! }
-//!
-//! #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! enum MyOps {
-//!    StringLength(StringLength),
 //! }
 //! ```
 //!
 //! ### Defining a [`Monoid`]:
 //!
 //! ```
-//! use paladin::{operation::{Monoid, Operation, Result}, opkind_derive::OpKind};
+//! use paladin::{RemoteExecute, operation::{Monoid, Operation, Result}};
 //! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+//! #[derive(Serialize, Deserialize, RemoteExecute)]
 //! struct StringConcat;
 //!
 //! impl Monoid for StringConcat {
 //!     type Elem = String;
-//!     type Kind = MyOps;
 //!     
 //!     fn combine(&self, a: Self::Elem, b: Self::Elem) -> Result<Self::Elem> {
 //!         Ok(a + &b)
@@ -93,140 +68,51 @@
 //!         String::new()
 //!     }
 //! }
-//!
-//! #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! enum MyOps {
-//!    StringConcat(StringConcat),
-//! }
 //! ```
 //!
 //! ### An [`Operation`] with constructor arguments:
 //!
 //! ```
-//! use paladin::{operation::{Monoid, Operation, Result}, opkind_derive::OpKind};
+//! use paladin::{RemoteExecute, operation::{Monoid, Operation, Result}};
 //! use serde::{Deserialize, Serialize};
 //!
-//! #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
+//! #[derive(Serialize, Deserialize, RemoteExecute)]
 //! struct MultiplyBy(i32);
 //!
 //! impl Operation for MultiplyBy {
 //!     type Input = i32;
 //!     type Output = i32;
-//!     type Kind = MyOps;
 //!     
 //!     fn execute(&self, input: Self::Input) -> Result<Self::Output> {
 //!         Ok(self.0 * input)
 //!     }
 //! }
-//!
-//! #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! enum MyOps {
-//!     MultiplyBy(MultiplyBy),
-//! }
 //! ```
-//!
-//! ### Defining a polymorphic [`Monoid`]:
-//!
-//! ```
-//! use paladin::{
-//!     operation::{Monoid, Operation, Result},
-//!     opkind_derive::OpKind,
-//!     serializer::Serializable,
-//! };
-//! use serde::{Deserialize, Serialize};
-//! use std::{ops::Mul, fmt::Debug};
-//! use num_traits::One;
-//!
-//! #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
-//! struct GenericMultiplication<T>(std::marker::PhantomData<T>);
-//!
-//! impl<T: Mul<Output = T> + One + Serializable + Debug + Clone> Monoid for GenericMultiplication<T>
-//! where
-//!     MyOps: From<GenericMultiplication<T>>,
-//! {
-//!     type Elem = T;
-//!     type Kind = MyOps;
-//!
-//!     fn empty(&self) -> Self::Elem {
-//!         T::one()
-//!     }
-//!
-//!     fn combine(&self, a: Self::Elem, b: Self::Elem) -> Result<Self::Elem> {
-//!         Ok(a * b)
-//!     }
-//! }
-//!
-//! #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! enum MyOps {
-//!     // Monomorphize
-//!     GenericMultiplicationI32(GenericMultiplication<i32>),
-//!     GenericMultiplicationI64(GenericMultiplication<i64>),
-//! }
-//! ```
-//!
-//! Later on ...
-//! ```
-//! # use paladin::{
-//! #    operation::{Monoid, Operation, Result},
-//! #    opkind_derive::OpKind,
-//! #    serializer::Serializable,
-//! # };
-//! # use serde::{Deserialize, Serialize};
-//! # use std::{ops::Mul, fmt::Debug};
-//! # use num_traits::One;
-//! #
-//! # #[derive(Serialize, Deserialize, Debug, Clone, Copy, Default)]
-//! # struct GenericMultiplication<T>(std::marker::PhantomData<T>);
-//! #
-//! # impl<T: Mul<Output = T> + One + Serializable + Debug + Clone> Monoid for GenericMultiplication<T>
-//! # where
-//! #    MyOps: From<GenericMultiplication<T>>,
-//! # {
-//! #    type Elem = T;
-//! #    type Kind = MyOps;
-//! #
-//! #    fn empty(&self) -> Self::Elem {
-//! #        T::one()
-//! #    }
-//! #
-//! #    fn combine(&self, a: Self::Elem, b: Self::Elem) -> Result<Self::Elem> {
-//! #        Ok(a * b)
-//! #    }
-//! # }
-//! #
-//! # #[derive(OpKind, Serialize, Deserialize, Debug, Clone, Copy)]
-//! # enum MyOps {
-//! #    // Monomorphize
-//! #    GenericMultiplicationI32(GenericMultiplication<i32>),
-//! #    GenericMultiplicationI64(GenericMultiplication<i64>),
-//! # }
-//! #
-//! use paladin::{
-//!     directive::{IndexedStream, Directive},
-//! };
-//!
-//! #[tokio::main]
-//! async fn main() {
-//!     let computation = IndexedStream::from([1, 2, 3, 4, 5, 6])
-//!         .fold(GenericMultiplication::<i32>::default());
-//! }
-//! ```
-
 use std::fmt::Debug;
 
 use crate::serializer::{Serializable, Serializer};
+
+/// An operation that is identifiable and executable by the runtime in a
+/// distributed environment.
+///
+/// It is used to facilitate serialization, deserialization, and dynamic
+/// execution of operations.
+///
+/// These will be automatically implemented by the
+/// [`RemoteExecute`](crate::RemoteExecute) derive macro.
+pub trait RemoteExecute {
+    const ID: u8;
+}
 
 /// An operation that can be performed by a worker.
 ///
 /// Akin to a function that maps an input to an output, it defines the signature
 /// and semantics of a computation.
-pub trait Operation: Serializable + Clone + Debug + Into<Self::Kind> {
+pub trait Operation: RemoteExecute + Serializable {
     /// The input type of the operation.
     type Input: Serializable + Debug;
     /// The output type of the operation.
     type Output: Serializable + Debug;
-    /// The operation registry type.
-    type Kind: OpKind;
 
     /// Execute the operation on the given input.
     fn execute(&self, input: Self::Input) -> Result<Self::Output>;
@@ -259,46 +145,22 @@ pub trait Operation: Serializable + Clone + Debug + Into<Self::Kind> {
             .map_err(|err| FatalError::from_anyhow(err, Default::default()))?;
         Ok(output)
     }
+
+    fn from_bytes(serializer: Serializer, input: &[u8]) -> Result<Self> {
+        let this = serializer
+            .from_bytes(input)
+            .map_err(|err| FatalError::from_anyhow(err, Default::default()))?;
+        Ok(this)
+    }
 }
 
-/// A registry of all available operations.
-///
-/// Implementations MUST be an enum. The implementation should group all
-/// available [`Operation`]s into a single registry. This enables operations to
-/// be serialized and executed by a remote service in an opaque manner. In
-/// particular, the remote service need not know the exact type of operation,
-/// but rather, only the _kind_ of possible operations.
-///
-/// Note that a [`Runtime`](crate::runtime::Runtime) instance expects to be
-/// specialized with an [`OpKind`] type -- this is what enables dynamic
-/// execution behavior across all available operations.
-///
-/// # Design rationale
-/// In a world where operations are all executed in the same process, `Box<dyn
-/// Operation>` would theoretically suffice. However, in a distributed system,
-/// we need to serialize operations and send them back and forth between remote
-/// machines. Generic trait object serialization / deserialization is
-/// non-trivial and is not supported by [`serde`] out of the box. Solutions
-/// like <https://docs.rs/typetag> were explored, but, unfortunately, they do
-/// not support generic types.
-///
-/// A `proc_macro_derive` is provided to simplify the process of facilitating
-/// opaque execution of operations, [`crate::opkind_derive`]. It is highly
-/// recommended to use this derive macro to implement [`OpKind`] for your
-/// operation registry, as there are a lot of boilerplate details that need to
-/// be taken care of.
-pub trait OpKind: Serializable + Clone + Debug {}
-
 /// An associative binary [`Operation`].
-pub trait Monoid: Serializable + Clone + Debug + Into<Self::Kind> {
+pub trait Monoid: RemoteExecute + Serializable {
     /// The type of the elements that can be combined by the operation.
     /// Note that unlike an [`Operation`], a [`Monoid`] is a binary operation on
     /// elements of the same type. As such, it does not have distinct
     /// `Input` and `Output` types, but rather, a single `Elem` type.
     type Elem: Serializable + Debug;
-
-    /// The operation registry type.
-    type Kind: OpKind;
 
     /// Get the identity element of the operation. Practically, this will be
     /// used when attempting to fold over a collection of elements, and that
@@ -320,12 +182,121 @@ where
     /// The output type is a single, combined, element of the same type.
     type Output = T::Elem;
 
-    type Kind = T::Kind;
-
     /// Execute the operation on the given input.
     fn execute(&self, (a, b): Self::Input) -> Result<Self::Output> {
         self.combine(a, b)
     }
+}
+
+/// Marker types for [`Operation`]s.
+pub mod marker {
+    /// A [`Marker`] that can be used like [`Phantom`](std::marker::PhantomData)
+    /// to force module inclusion of [`Operation`](super::Operation)
+    /// implementations.
+    #[derive(Clone, Copy)]
+    pub struct Marker;
+}
+
+/// Generate an operation registry for external crates.
+///
+/// This macro generates a `register()` function that can be used to force
+/// module inclusion of [`Operation`] implementations.
+///
+/// Note this is only necessary for operations that are defined in a crate
+/// external to the worker runtime instantiation. If the operations are defined
+/// in the same crate as the worker runtime instantiation, then the operations
+/// will naturally be included in the worker runtime binary.
+///
+/// The `register()` function must be defined _within_ the external operations
+/// module such that it is imported and called _from_ the worker module. This
+/// scheme ensures that the compiler does not exclude the external operations
+/// from its compilation.
+///
+/// **You will have problems if your operations are defined in a separate crate
+/// from your worker runtime and you do not call this macro from within your
+/// operation module.**
+///
+/// # Example
+/// Let's say you have a workspace with the following structure:
+/// ```text
+/// my_workspace
+/// ├── my_operations
+/// │   ├── Cargo.toml
+/// │   └── src
+/// │       └── lib.rs
+/// └── my_worker
+///    ├── Cargo.toml
+///    └── src
+///         └── main.rs
+/// ```
+///
+/// In `my_operations`, you define your operations:
+/// ```
+/// use paladin::{registry, RemoteExecute, operation::{Operation, Result}};
+/// use serde::{Deserialize, Serialize};
+///
+/// #[derive(Serialize, Deserialize, RemoteExecute)]
+/// struct MyOperation;
+///
+/// impl Operation for MyOperation {
+///     type Input = ();
+///     type Output = ();
+///     
+///     fn execute(&self, _input: Self::Input) -> Result<Self::Output> {
+///         Ok(())
+///     }
+/// }
+///
+/// // A `register()` function is generated and exported by the `registry!()` macro.
+/// // This must be called from within the operation module.
+/// registry!();
+/// ```
+///
+/// In `my_worker`, you instantiate the worker runtime:
+/// ```
+/// # mod my_operations {
+/// #    use paladin::{registry, RemoteExecute, operation::{Operation, Result}};
+/// #    use serde::{Deserialize, Serialize};
+/// #
+/// #    #[derive(Serialize, Deserialize, RemoteExecute)]
+/// #    struct MyOperation;
+/// #
+/// #    impl Operation for MyOperation {
+/// #        type Input = ();
+/// #        type Output = ();
+/// #    
+/// #        fn execute(&self, _input: Self::Input) -> Result<Self::Output> {
+/// #            Ok(())
+/// #        }
+/// #    }
+/// #
+/// #    registry!();
+/// # }
+/// #
+/// use paladin::{runtime::WorkerRuntime, config::{Config, Runtime}};
+/// use my_operations::register;
+///
+/// #[tokio::main]
+/// async fn main() -> anyhow::Result<()> {
+///     let config = Config {
+///         runtime: Runtime::InMemory,
+///         ..Default::default()
+///     };
+///
+///     let runtime = WorkerRuntime::from_config(&config, register()).await?;
+///
+///     Ok(())
+/// }
+/// ```
+#[macro_export]
+macro_rules! registry {
+    () => {
+        /// Register external operations with the runtime.
+        #[inline(never)]
+        pub fn register() -> ::paladin::operation::marker::Marker {
+            ::paladin::operation::marker::Marker
+        }
+    };
 }
 
 mod error;

--- a/paladin-core/src/queue/in_memory.rs
+++ b/paladin-core/src/queue/in_memory.rs
@@ -144,7 +144,7 @@ impl ExactlyOnceQueue {
     }
 
     fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()> {
-        let bytes = Bytes::from(self.serializer.to_bytes(payload)?);
+        let bytes = self.serializer.to_bytes(payload)?;
         self.messages.push(bytes.clone());
         self.num_messages.add_permits(1);
         Ok(())
@@ -239,7 +239,7 @@ impl BroadcastQueue {
     }
 
     fn publish<PayloadTarget: Serializable>(&self, payload: &PayloadTarget) -> Result<()> {
-        let bytes = Bytes::from(self.serializer.to_bytes(payload)?);
+        let bytes = self.serializer.to_bytes(payload)?;
         // Assign a unique message ID to the message such that consumers can
         // track which messages they've seen.
         let message_id = self.message_counter.fetch_add(1, Ordering::Relaxed);

--- a/paladin-core/src/runtime/dynamic_channel.rs
+++ b/paladin-core/src/runtime/dynamic_channel.rs
@@ -13,6 +13,7 @@
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use futures::{Sink, Stream, StreamExt};
+use uuid::Uuid;
 
 use crate::{
     acker::Acker,
@@ -97,7 +98,7 @@ pub enum DynamicChannelFactory {
 impl ChannelFactory for DynamicChannelFactory {
     type Channel = DynamicChannel;
 
-    async fn get(&self, identifier: &str, channel_type: ChannelType) -> Result<DynamicChannel> {
+    async fn get(&self, identifier: Uuid, channel_type: ChannelType) -> Result<DynamicChannel> {
         match self {
             Self::Amqp(factory) => Ok(DynamicChannel::Amqp(
                 factory.get(identifier, channel_type).await?,
@@ -108,7 +109,7 @@ impl ChannelFactory for DynamicChannelFactory {
         }
     }
 
-    async fn issue(&self, channel_type: ChannelType) -> Result<(String, DynamicChannel)> {
+    async fn issue(&self, channel_type: ChannelType) -> Result<(Uuid, DynamicChannel)> {
         match self {
             Self::Amqp(factory) => {
                 let (identifier, channel) = factory.issue(channel_type).await?;

--- a/paladin-core/src/runtime/mod.rs
+++ b/paladin-core/src/runtime/mod.rs
@@ -117,13 +117,14 @@ pub struct Runtime {
     task_channel: DynamicChannel,
     serializer: Serializer,
     worker_emulator: Option<Vec<JoinHandle<Result<()>>>>,
+    _marker: Marker,
 }
 const TASK_BUS_ROUTING_KEY: Uuid = Uuid::nil();
 const IPC_ROUTING_KEY: Uuid = Uuid::max();
 
 impl Runtime {
     /// Initializes the [`Runtime`] with the provided [`Config`].
-    pub async fn from_config(config: &Config) -> Result<Self> {
+    pub async fn from_config(config: &Config, marker: Marker) -> Result<Self> {
         let channel_factory = DynamicChannelFactory::from_config(config).await?;
         let task_channel = channel_factory
             .get(TASK_BUS_ROUTING_KEY, ChannelType::ExactlyOnce)
@@ -145,6 +146,7 @@ impl Runtime {
             task_channel,
             serializer,
             worker_emulator,
+            _marker: marker,
         })
     }
 
@@ -154,7 +156,7 @@ impl Runtime {
             runtime: crate::config::Runtime::InMemory,
             ..Default::default()
         };
-        Self::from_config(&config).await
+        Self::from_config(&config, Marker).await
     }
 
     /// Spawns an emulator for the worker runtime.

--- a/paladin-core/src/serializer/mod.rs
+++ b/paladin-core/src/serializer/mod.rs
@@ -32,7 +32,7 @@
 //! ```
 
 use anyhow::Result;
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
 use crate::config::{self, Config};
@@ -44,8 +44,8 @@ use crate::config::{self, Config};
 /// hence the requirements for `Send`, `Sync`, and `Unpin`. As such, it's
 /// recommended to use owned types for serialization and deserialization to
 /// ensure compatibility with this trait.
-pub trait Serializable: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static {}
-impl<T> Serializable for T where T: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static {}
+pub trait Serializable: Serialize + for<'de> Deserialize<'de> + Send + Sync + Unpin {}
+impl<T> Serializable for T where T: Serialize + for<'de> Deserialize<'de> + Send + Sync + Unpin {}
 
 /// Provides a unified interface for serializing and deserializing binary data.
 ///

--- a/paladin-core/src/serializer/mod.rs
+++ b/paladin-core/src/serializer/mod.rs
@@ -32,6 +32,7 @@
 //! ```
 
 use anyhow::Result;
+use bytes::{BufMut, Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 
@@ -72,15 +73,16 @@ impl std::fmt::Display for Serializer {
 impl Serializer {
     /// Serializes the given value into binary data using the specified format.
     #[instrument(skip(value), level = "trace")]
-    pub fn to_bytes<T: Serialize>(&self, value: &T) -> Result<Vec<u8>> {
-        match self {
-            Self::Postcard => Ok(postcard::to_allocvec(value)?),
+    pub fn to_bytes<T: Serialize>(&self, value: &T) -> Result<Bytes> {
+        let mut buf = BytesMut::new().writer();
+        let buf = match self {
+            Self::Postcard => postcard::to_io(value, buf)?,
             Self::Cbor => {
-                let mut result = Vec::new();
-                ciborium::into_writer(value, &mut result)?;
-                Ok(result)
+                ciborium::into_writer(value, &mut buf)?;
+                buf
             }
-        }
+        };
+        Ok(buf.into_inner().freeze())
     }
 
     /// Deserializes the given binary data into a value of the specified type

--- a/paladin-core/src/task/mod.rs
+++ b/paladin-core/src/task/mod.rs
@@ -7,6 +7,7 @@
 use std::fmt::Debug;
 
 use anyhow::Result;
+use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -66,13 +67,13 @@ pub struct AnyTask {
     /// be sent.
     pub routing_key: Uuid,
     /// Serialized metadata associated with the [`Task`].
-    pub metadata: Vec<u8>,
+    pub metadata: Bytes,
     /// The serialized [`Operation`] to be executed.
-    pub op: Vec<u8>,
+    pub op: Bytes,
     /// The unique identifier of the [`Operation`] to be executed.
     pub operation_id: u8,
     /// Serialized arguments to the [`Operation`].
-    pub input: Vec<u8>,
+    pub input: Bytes,
     /// The [`Serializer`] used to serialize and deserialize the [`Operation`]
     /// arguments.
     pub serializer: Serializer,
@@ -82,9 +83,9 @@ pub struct AnyTask {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AnyTaskOutput {
     /// Serialized metadata associated with the [`Task`].
-    pub metadata: Vec<u8>,
+    pub metadata: Bytes,
     /// Serialized output of the [`Operation`] execution.
-    pub output: Vec<u8>,
+    pub output: Bytes,
     /// The [`Serializer`] used to serialize and deserialize the [`Operation`].
     pub serializer: Serializer,
 }

--- a/paladin-core/src/task/mod.rs
+++ b/paladin-core/src/task/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::Debug;
 
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::{
     __private::OPERATIONS,
@@ -30,7 +31,7 @@ pub struct Task<'a, Op: Operation, Metadata: Serializable> {
     /// The routing key used to identify the
     /// [`Channel`](crate::channel::Channel) to which execution results should
     /// be sent.
-    pub routing_key: String,
+    pub routing_key: Uuid,
     /// Metadata associated with the [`Task`].
     pub metadata: Metadata,
     /// The [`Operation`] to be executed.
@@ -63,7 +64,7 @@ pub struct AnyTask {
     /// The routing key used to identify the
     /// [`Channel`](crate::channel::Channel) to which execution results should
     /// be sent.
-    pub routing_key: String,
+    pub routing_key: Uuid,
     /// Serialized metadata associated with the [`Task`].
     pub metadata: Vec<u8>,
     /// The serialized [`Operation`] to be executed.
@@ -117,7 +118,7 @@ pub enum AnyTaskResult {
 impl<'a, Op: Operation, Metadata: Serializable> Task<'a, Op, Metadata> {
     /// Convert a [`Task`] into an opaque [`AnyTask`].
     pub fn into_any_task(self, serializer: Serializer) -> Result<AnyTask> {
-        let routing_key = self.routing_key.to_string();
+        let routing_key = self.routing_key;
         let metadata = serializer.to_bytes(&self.metadata)?;
         let input = serializer.to_bytes(&self.input)?;
         let op = serializer.to_bytes(self.op)?;

--- a/paladin-opkind-derive/Cargo.toml
+++ b/paladin-opkind-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "paladin-opkind-derive"
-version = "0.3.1"
+version = "0.4.0"
 description = "Derive macro for paladin."
 license.workspace = true
 edition.workspace = true

--- a/paladin-opkind-derive/src/lib.rs
+++ b/paladin-opkind-derive/src/lib.rs
@@ -130,8 +130,8 @@ pub fn operation_derive(input: TokenStream) -> TokenStream {
                             op.execute(input)
                         ))
                         // Convert panics to fatal operation errors.
-                        .map_err(|e| #paladin_path::operation::FatalError::from_str(
-                            &format!("operation {} panicked: {e:?}", stringify!(#name)),
+                        .map_err(|_| #paladin_path::operation::FatalError::from_str(
+                            &format!("operation {} panicked", stringify!(#name)),
                             #paladin_path::operation::FatalStrategy::Terminate
                         ))??;
 

--- a/paladin-opkind-derive/src/lib.rs
+++ b/paladin-opkind-derive/src/lib.rs
@@ -1,198 +1,162 @@
-//! A derive macro for the `OpKind` trait.
-//!
-//! Implementing types MUST be an enum. More specifically, the enum variants
-//! MUST be single tuple structs, where the tuple is the type of the operation.
-//! For example:
-//!
-//! ```
-//! struct OpA;
-//! struct OpB;
-//! struct OpC;
-//!
-//! enum MyOps {
-//!     OpA(OpA),
-//!     OpB(OpB),
-//!     OpC(OpC),
-//! }
-//! ```
-//!
-//! This is what enables a pattern match on the enum to extract the operation.
+//! A derive macro for the `RemoteExecute` trait.
 //!
 //! This construction enables operations to be serialized and executed by a
-//! remote service in an opaque manner. In particular, the remote service need
-//! not know the exact type of operation, but rather, only the _kind_ of
-//! possible operations. This macro takes care of generating the necessary code
-//! to facilitate this.
-//!
-//! One should consolidate all operations into a single enum, which serves
-//! as the registry of all available operations. The registry should be
-//! exhaustive, in the sense that all possible operations one would like to be
-//! able to execute should be included. This is because the `Runtime` is
-//! specialized to a single `OpKind` type, and thus, can only execute operations
-//! defined therein. Of course, you're free to instantiate multiple `Runtime`
-//! instances to manage different sets of operations.
+//! remote service in an opaque manner. It uses the [`linkme`](https://docs.rs/linkme)
+//! crate to collect all operation execution pointers into a single slice that
+//! are gathered into a contiguous section of the binary by the linker.
 //!
 //! # Implementation details
 //!
-//! This macro does a few things:
-//! 1. It implements the `OpKind` trait for the enum.
-//! 2. It implements `From` for each variant of the enum, allowing you to
-//!    convert from the operation type to the enum.
-//! 3. It implements `RemoteExecute` for `AnyTask` where the `OpKind` is the
-//!    enum.
-//! This is perhaps the most important part of the macro, as it is what enables
-//! remote execution of operations. It takes care of deserializing the input,
-//! executing the operation, serializing the output, and sending the result back
-//! to the receiving channel.
+//! A globally unique identifier is assigned to each operation. Then, a unique
+//! function that handles deserialization, execution, and re-serialization of
+//! the result is generated for each operation. A pointer to this function is
+//! registered with the distributed slice at the index of the operation's
+//! identifier. This allows execution function to be dereferenced by only the
+//! operation identifier, which is serialized with the task.
+//!
+//! This scheme allows the tasks sent to workers to be opaque, while still
+//! enabling efficient lookup and execution of the appropriate operation.
 extern crate proc_macro;
+
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields, Ident, Type};
+use syn::{parse_macro_input, Attribute, DeriveInput, Error, Ident, Result};
 
-fn parse_type_arguments(path_arguments: &syn::PathArguments) -> Vec<syn::Type> {
-    match path_arguments {
-        syn::PathArguments::None => Vec::new(),
-        syn::PathArguments::AngleBracketed(angle_bracketed_args) => angle_bracketed_args
-            .args
-            .iter()
-            .filter_map(|arg| {
-                if let syn::GenericArgument::Type(ty) = arg {
-                    Some(ty.clone())
-                } else {
-                    None
+static OPERATION_ID_COUNTER: AtomicU8 = AtomicU8::new(0);
+
+/// Check if the `internal` attribute is present on the derive macro.
+///
+/// Quoted variables need to be slightly modified if the macro is being
+/// called from the `paladin` crate itself.
+fn get_is_internal(attrs: &mut Vec<Attribute>) -> Result<bool> {
+    let mut is_internal = None;
+    let mut errors: Option<Error> = None;
+
+    attrs.retain(|attr| {
+        if !attr.path().is_ident("paladin") {
+            return true;
+        }
+        if let Err(err) = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("internal") {
+                if is_internal.is_some() {
+                    return Err(meta.error("duplicate paladin crate attribute"));
                 }
-            })
-            .collect(),
-        syn::PathArguments::Parenthesized(_) => Vec::new(),
+
+                is_internal = Some(true);
+                Ok(())
+            } else {
+                Err(meta.error("unsupported paladin attribute"))
+            }
+        }) {
+            match &mut errors {
+                None => errors = Some(err),
+                Some(errors) => errors.combine(err),
+            }
+        }
+        false
+    });
+
+    match errors {
+        None => Ok(is_internal.unwrap_or(false)),
+        Some(errors) => Err(errors),
     }
 }
 
 /// See the [module level documentation](crate) for more information.
-#[proc_macro_derive(OpKind)]
-pub fn op_kind_derive(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+#[proc_macro_derive(RemoteExecute, attributes(paladin))]
+pub fn operation_derive(input: TokenStream) -> TokenStream {
+    let mut input = parse_macro_input!(input as DeriveInput);
 
-    let name = &input.ident;
-    // Extract the variant names and their types for the enum
-    let variants: Vec<(Ident, Ident, Vec<Type>)> = if let Data::Enum(data_enum) = &input.data {
-        data_enum
-            .variants
-            .iter()
-            .map(|variant| {
-                let variant_name = &variant.ident;
-                if let Fields::Unnamed(fields) = &variant.fields {
-                    if let Some(field) = fields.unnamed.first() {
-                        if let syn::Type::Path(type_path) = &field.ty {
-                            let type_name = &type_path.path.segments.first().unwrap().ident;
-                            let generics = parse_type_arguments(
-                                &type_path.path.segments.first().unwrap().arguments,
-                            );
-
-                            return (variant_name.clone(), type_name.clone(), generics);
-                        }
-                    }
-                }
-                panic!("OpKind expects variants to have a single unnamed field");
-            })
-            .collect()
-    } else {
-        panic!("OpKind can only be derived for enums");
+    let is_internal = match get_is_internal(&mut input.attrs) {
+        Ok(path) => path,
+        Err(err) => return err.to_compile_error().into(),
     };
 
-    let match_arms = variants
-        .iter()
-        .map(|(variant_name, _, _)| {
-            quote! {
-                #name::#variant_name(ref op) => {
-                    let input = op.input_from_bytes(self.serializer, &self.input)?;
+    // The path to the `paladin` crate.
+    // If the derive macro is being called from the `paladin` crate itself, then
+    // the path is `crate`, otherwise it is `::paladin`.
+    let paladin_path = if is_internal {
+        quote! { crate }
+    } else {
+        quote! { ::paladin }
+    };
 
-                    ::paladin::tracing::debug!("executing operation with input: {input:?}");
+    // If the derive macro is being called from the `paladin` crate itself, then
+    // the `linkme` attribute is not needed.
+    // Otherwise, we need to point the `linkme` attribute to the `paladin` so that
+    // consumers of the derive macro do not need to add the `linkme` crate as a
+    // dependency.
+    let linkme_path_override = if is_internal {
+        quote! {}
+    } else {
+        quote! {
+            #[linkme(crate=#paladin_path::__private::linkme)]
+        }
+    };
 
+    let name = &input.ident;
+    let generics = &input.generics;
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let operation_id = OPERATION_ID_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let function_name = Ident::new(&format!("__execute_{}", operation_id), name.span());
+
+    let expanded = quote! {
+        impl #impl_generics #paladin_path::operation::RemoteExecute for #name #ty_generics #where_clause {
+            const ID: u8 = #operation_id;
+        }
+
+        #[#paladin_path::__private::linkme::distributed_slice(#paladin_path::__private::OPERATIONS)]
+        #linkme_path_override
+        fn #function_name(task: #paladin_path::task::AnyTask) -> #paladin_path::__private::futures::future::BoxFuture<
+            'static,
+            #paladin_path::operation::Result<#paladin_path::task::AnyTaskOutput>
+        > {
+            Box::pin(async move {
+                // Deserialize the operation.
+                let op = #name::from_bytes(task.serializer, &task.op)?;
+
+                // Define the execution logic in a closure so that it can be retried if it fails.
+                let get_result = || {
+                    // Deserialize the input.
+                    let input = op.input_from_bytes(task.serializer, &task.input)?;
+                    #paladin_path::__private::tracing::debug!(operation = %stringify!(#name), input = ?input, "executing operation");
+
+                    // Execute the operation, catching panics.
                     let output = std::panic::catch_unwind(::std::panic::AssertUnwindSafe(||
                         op.execute(input)
                     ))
-                    .map_err(|_| ::paladin::operation::FatalError::from_str(
+                    // Convert panics to fatal operation errors.
+                    .map_err(|_| #paladin_path::operation::FatalError::from_str(
                         &format!("operation panicked"),
-                        ::paladin::operation::FatalStrategy::Terminate
+                        #paladin_path::operation::FatalStrategy::Terminate
                     ))??;
 
-                    ::paladin::tracing::debug!("operation executed successfully: {:?}", output);
+                    #paladin_path::__private::tracing::debug!(operation = %stringify!(#name), output = ?output, "operation executed successfully");
 
-                    let serialized_output = op.output_to_bytes(self.serializer, output)?;
-                    let serialized_op = op.as_bytes(self.serializer)?;
-
-                    let response = ::paladin::task::AnyTaskOutput {
-                        metadata: self.metadata.clone(),
-                        op: serialized_op,
-                        output: serialized_output,
-                        serializer: self.serializer,
-                    };
-
-                    Ok(response)
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-
-    // Generate the From implementations
-    let impls = variants
-        .iter()
-        .map(|(variant_name, type_name, generics)| {
-            if generics.is_empty() {
-                quote! {
-                    impl From<#type_name> for #name {
-                        fn from(op: #type_name) -> Self {
-                            #name::#variant_name(op)
-                        }
-                    }
-                }
-            } else {
-                let generics_ident = generics
-                    .iter()
-                    .map(|generic| {
-                        if let syn::Type::Path(type_path) = generic {
-                            &type_path.path.segments.first().unwrap().ident
-                        } else {
-                            panic!("Expected a TypePath");
-                        }
-                    })
-                    .collect::<Vec<_>>();
-                quote! {
-                    impl From<#type_name<#(#generics_ident),*>> for #name {
-                        fn from(op: #type_name<#(#generics_ident),*>) -> Self {
-                            #name::#variant_name(op)
-                        }
-                    }
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-
-    let expanded = quote! {
-        impl ::paladin::operation::OpKind for #name {}
-
-        #(#impls)*
-
-        #[::paladin::async_trait]
-        impl ::paladin::task::RemoteExecute<#name> for ::paladin::task::AnyTask<#name> {
-            async fn remote_execute(&self, runtime: &::paladin::runtime::WorkerRuntime<#name>) -> ::paladin::operation::Result<::paladin::task::AnyTaskOutput> {
-                let get_result = || async {
-                    (match self.op_kind {
-                        #(#match_arms)*,
-                    }) as ::paladin::operation::Result<::paladin::task::AnyTaskOutput>
+                    // Serialize the output.
+                    Ok(op.output_to_bytes(task.serializer, output)?) as #paladin_path::operation::Result<Vec<u8>>
                 };
 
-                match get_result().await {
+                let result = match get_result() {
                     Err(err) => {
-                        err.retry_trace(get_result, |e| {
-                            ::paladin::tracing::warn!("transient operation failure {e:?}");
+                        // If the operation failed, it according to the error's retry strategy.
+                        err.retry_trace(move || async move { get_result() }, |e| {
+                            #paladin_path::__private::tracing::warn!(operation = %stringify!(#name), error = ?e, "transient operation failure");
                         })
                         .await
                     },
                     result => result
-                }
-            }
+                };
+
+                // Convert the typed result into an opaque task output.
+                result.map(|output| #paladin_path::task::AnyTaskOutput {
+                    metadata: task.metadata,
+                    output,
+                    serializer: task.serializer,
+                })
+            })
         }
     };
 

--- a/paladin-opkind-derive/src/lib.rs
+++ b/paladin-opkind-derive/src/lib.rs
@@ -135,9 +135,10 @@ pub fn operation_derive(input: TokenStream) -> TokenStream {
                             #paladin_path::operation::FatalStrategy::Terminate
                         ))??;
 
+                        #paladin_path::__private::tracing::debug!(operation = %stringify!(#name), output = ?typed_output, "operation executed successfully");
+
                         // Serialize the output.
                         let serialized_output = op.output_to_bytes(task.serializer, typed_output)?;
-                        #paladin_path::__private::tracing::debug!(operation = %stringify!(#name), output = ?serialized_output, "operation executed successfully");
 
                         Ok(serialized_output) as #paladin_path::operation::Result<Vec<u8>>
                     })

--- a/paladin-opkind-derive/src/lib.rs
+++ b/paladin-opkind-derive/src/lib.rs
@@ -140,7 +140,7 @@ pub fn operation_derive(input: TokenStream) -> TokenStream {
                         // Serialize the output.
                         let serialized_output = op.output_to_bytes(task.serializer, typed_output)?;
 
-                        Ok(serialized_output) as #paladin_path::operation::Result<Vec<u8>>
+                        Ok(serialized_output) as #paladin_path::operation::Result<#paladin_path::__private::bytes::Bytes>
                     })
                     .await
                     .map_err(|e| #paladin_path::operation::FatalError::new(
@@ -148,7 +148,7 @@ pub fn operation_derive(input: TokenStream) -> TokenStream {
                         #paladin_path::operation::FatalStrategy::Terminate
                     ))??;
 
-                    Ok(output) as #paladin_path::operation::Result<Vec<u8>>
+                    Ok(output) as #paladin_path::operation::Result<#paladin_path::__private::bytes::Bytes>
                 };
 
                 let result = match get_result().await {


### PR DESCRIPTION
## Removing `'static` and `Clone` requirements
The signature of `Task` has been updated to accept references to operations, rather than an owned value. This requires threading lifetimes through directive chains such that the compiler can guarantee the passed in operations live as long as the execution chain. The implication with respect to the public API is that operations must be passed as references to directive chainers like `.map()` and `.fold()`. Ultimately this means that directive implementations of `Functor` and `Foldable` no longer need to clone operations, and can simply hold a single immutable reference to operations through the duration of execution. This is a significant efficiency improvement, especially for large operation payloads and large input streams.

## Reworking the `derive` procedural macro
A significant ergonomic improvement to the `derive` macro is included here. Previously, `Operation` implementors were required to maintain an `enum` of all `Operation` definitions to facilitate dynamic remote execution. This scheme has been superseded by a `#[derive(RemoteExecute)]` that can be derived directly on `Operation`s. Operations annotated with `#[derive(RemoteExecute)]` will now be automatically collected at compile time into a contiguous section of the binary by the linker — no more manual maintenance of a comprehensive `enum`.

This change was precipitated by the aforementioned `'static` and `Clone` requirements for `Operation` being dropped. With those requirements dropped, and `Task` requiring a lifetime annotation, the `OpKind` `enum` would have had to additionally define a lifetime annotated version with references to the internal operations.

For example:
```rust
struct MyOperation;

impl Operation for MyOperation {
    // ...
    type Kind = MyOps;
}

#[derive(OpKind)]
enum MyOps {
    MyOperation(MyOperation)
}
```

With `Task` requiring a reference to the `OpKind`, rather than an owned copy, an additional lifetime would need to be introduced onto `Operation` to support a variant of the `MyOps` containing references.

```rust
struct MyOperation;

impl<'a> Operation<'a> for MyOperation {
    // ...
    type KindRef = MyOpsRef<'a>;
    type Kind = MyOps;
}

#[derive(OpKind)]
enum MyOps {
    MyOperation(MyOperation)
}

#[derive(OpKind)]
enum MyOpsRef<'a> {
    MyOperation(&'a MyOperation)
}
```

Which was rather unfortunate for the public API. I took this as an opportunity to simplify the public API consumers. As such, the `RemoteExecute` trait was introduced.
```rust
pub trait RemoteExecute {
    const ID: u8;
}
``` 
This is accompanied by a derive macro, which generates a unique `ID` for each `Operation` deriving `RemoteExecute`. This macro additionally generates a unique execution function with types specialized to the given `Operation`. A pointer to this function is then inserted into a [`distributed_slice`](https://github.com/dtolnay/linkme#distributed-slice), indexed by the `Operation`'s unique ID. With this scheme, `Task`s can simply include the given `Operation`'s ID in the payload, and the remote worker can use that to retrieve its associated execution function from the slice. This exhibits the same behavior of the previous `OpKind` enum construction without requiring such an enum to be maintained by the paladin user.