### PR TITLE
feat: Added env support for prog args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,7 @@ dependencies = [
 
 [[package]]
 name = "paladin-core"
-version = "0.4.4"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/paladin-core/src/config/mod.rs
+++ b/paladin-core/src/config/mod.rs
@@ -25,25 +25,25 @@ const HELP_HEADING: &str = "Paladin options";
 #[derive(Args, Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Default)]
 pub struct Config {
     /// Determines the serialization format to be used.
-    #[arg(long, short, help_heading = HELP_HEADING, value_enum, default_value_t = Serializer::Postcard)]
+    #[arg(long, short, help_heading = HELP_HEADING, value_enum, env = "PALADIN_SERIALIZER", default_value_t = Serializer::Postcard)]
     pub serializer: Serializer,
 
     /// Specifies the runtime environment to use.
-    #[arg(long, short, help_heading = HELP_HEADING, value_enum, default_value_t = Runtime::Amqp)]
+    #[arg(long, short, help_heading = HELP_HEADING, value_enum, env = "PALADIN_RUNTIME", default_value_t = Runtime::Amqp)]
     pub runtime: Runtime,
 
     /// Specifies the number of worker threads to spawn (in memory runtime
     /// only).
-    #[arg(long, short, help_heading = HELP_HEADING)]
+    #[arg(long, short, help_heading = HELP_HEADING, env = "PALADIN_NUM_WORKERS")]
     pub num_workers: Option<usize>,
 
     /// Provides the URI for the AMQP broker, if the AMQP runtime is selected.
-    #[arg(long, help_heading = HELP_HEADING, env = "AMQP_URI", required_if_eq("runtime", "amqp"))]
+    #[arg(long, help_heading = HELP_HEADING, env = "PALADIN_AMQP_URI", required_if_eq("runtime", "amqp"))]
     pub amqp_uri: Option<String>,
 
     /// Provides the routing key for workers to listen on, if the AMQP runtime
     /// is used in configuration.
-    #[arg(long, help_heading = HELP_HEADING)]
+    #[arg(long, help_heading = HELP_HEADING, env = "PALADIN_TASK_BUS_ROUTING_KEY")]
     pub task_bus_routing_key: Option<String>,
 }
 

--- a/paladin-core/src/directive/indexed_stream/foldable.rs
+++ b/paladin-core/src/directive/indexed_stream/foldable.rs
@@ -85,7 +85,7 @@ struct Dispatcher<'a, M: Monoid> {
     channel_identifier: String,
 }
 
-impl<'a, Op: Monoid + 'static> Dispatcher<'a, Op> {
+impl<Op: Monoid + 'static> Dispatcher<'_, Op> {
     /// Queue the given [`TaskResult`].
     async fn queue(&self, result: TaskOutput<Op, Metadata>) {
         self.assembler.queue(result);


### PR DESCRIPTION
- The `zk_evm` leader bin just had env support added for it's prog args. However, some of its args are defined in `paladin`, so we needed to create a separate PR for this repo to add env support for the `paladin` specific prog args.
- See also PR [#786](https://github.com/0xPolygonZero/zk_evm/pull/786) in `zk_evm`.